### PR TITLE
docs: add deferred items tracker to Phase 2 plan

### DIFF
--- a/plans/phase2-agent-implementation-plan.md
+++ b/plans/phase2-agent-implementation-plan.md
@@ -668,7 +668,16 @@ Write Phase 2 completion report in `docs/development/phase2/phase2-completion-re
 - [ ] **Phase summary:** What Phase 2 delivered, total files added, total test count, overall coverage
 - [ ] **Consolidated issue log:** Aggregate all issues from step reports
 - [ ] **Consolidated decision log:** Aggregate all decisions from step reports
-- [ ] **Open items carried forward:** Features deferred to Phase 3+ (relay-side auth verification, relay-side stream routing, multi-tenant isolation)
+- [ ] **Open items carried forward:** Must include ALL of the following:
+  - **From Phase 1 (deferred through Phase 2):**
+    - Stream ID exhaustion / recycling (deferred to Phase 5)
+    - sync.Pool for Frame objects (deferred to Phase 5)
+    - Fuzz testing for FrameCodec (deferred to security phase)
+  - **From Phase 2 (new for Phase 3):**
+    - Relay-side mTLS verification (relay uses same auth but as server)
+    - Relay-side stream routing (TrafficRouter implementation)
+    - Multi-tenant isolation (AgentRegistry + per-customer stream scoping)
+    - Any new items discovered during Phase 2 implementation
 - [ ] **Architecture snapshot:** Current state of pkg/auth/, pkg/agent/, internal/config/, internal/audit/ -- file list, type list, interface satisfaction map
 - [ ] **Performance baseline:** Benchmark results for new code
 - [ ] **CI verification:** All CI jobs green on main

--- a/plans/prereqs/phase2/prereq-phase1-carryforward.md
+++ b/plans/prereqs/phase2/prereq-phase1-carryforward.md
@@ -47,6 +47,18 @@ Read `docs/development/phase1/phase1-completion-report.md` section "Open Items C
 
 Review each item above. If you disagree with any scoping decision, adjust before starting Phase 2.
 
+**Reviewed and confirmed by Ruben on 2026-03-28.** All scope decisions accepted. Deferred items must be carried forward in the Phase 2 completion report.
+
+## Deferred Items Tracker
+
+These items MUST appear in `docs/development/phase2/phase2-completion-report.md` under "Open Items Carried Forward" and be referenced in subsequent phase plans:
+
+| # | Item | Deferred To | Rationale |
+|---|------|-------------|-----------|
+| 4 | Stream ID exhaustion / recycling | Phase 5 (production hardening) | ~24 days before overflow at max load; acceptable pre-production |
+| 5 | sync.Pool for Frame objects | Phase 5 (production hardening) | Optimize after load testing confirms allocation pressure |
+| 6 | Fuzz testing for FrameCodec | Dedicated security phase | Security-specific testing, not blocking functionality |
+
 ## Done When
 
 - All 7 items reviewed and scope confirmed


### PR DESCRIPTION
## Summary

- Add explicit deferred items tracker table to `prereqs/phase2/prereq-phase1-carryforward.md` with 3 Phase 1 items that pass through Phase 2 untouched
- Update Phase 2 plan Step 6 completion report template to enumerate all carry-forward items (Phase 1 deferred + Phase 2 new)

Ensures no deferred items are lost between phases.

## Test plan

- [ ] Verify deferred items table in prereq-phase1-carryforward.md lists items 4, 5, 6
- [ ] Verify Phase 2 plan Step 6 "Open items carried forward" lists both Phase 1 and Phase 2 items