### PR TITLE
feat(config): relay config validation, port index, and env overrides

### DIFF
--- a/docs/development/phase3/step4-relay-config-report.md
+++ b/docs/development/phase3/step4-relay-config-report.md
@@ -1,0 +1,43 @@
+# Step 4 Report: Relay Config Loader Validation
+
+**Date:** 2026-03-29
+**Branch:** `phase3/relay-config`
+**PR:** pending
+**Status:** COMPLETED
+
+---
+
+## Summary
+
+Expanded the config loader with relay-specific validation, updated CustomerConfig to match the YAML format with port/service mappings, and added relay environment variable overrides and a BuildPortIndex utility.
+
+**Changes:**
+- CustomerConfig: replaced AllowedPorts/CustomerID with ID/Ports (PortConfig with port/service/description)
+- ServerConfig: added AdminAddr field
+- LoadRelayConfig: now validates required fields and applies env overrides
+- BuildPortIndex: builds port-to-customer-service map, detects duplicate port assignments
+- 8 new relay config tests
+
+## Issues Encountered
+
+| Issue | Root Cause | Fix |
+|-------|-----------|-----|
+| gofmt alignment on ServerConfig | Adding AdminAddr shifted field alignment | Ran gofmt |
+
+## Decisions Made
+
+1. **CustomerConfig.ID instead of CustomerID** -- Matches relay.example.yaml `id:` field. Shorter, cleaner in YAML.
+2. **BuildPortIndex as standalone function** -- Not a method on FileLoader. Pure function, easy to test, used by both config validation and relay startup.
+3. **Duplicate port detection** -- BuildPortIndex returns error if two customers claim the same port. Prevents misconfiguration that would cause routing ambiguity.
+
+## Deviations from Plan
+
+- None. Implemented exactly as planned.
+
+## Coverage Report
+
+```
+internal/config  92.1% of statements
+```
+
+20 tests total (12 agent + 8 relay).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type AgentConfig struct {
 // ServerConfig holds network listener and limit settings for the relay.
 type ServerConfig struct {
 	ListenAddr          string        `yaml:"listen_addr"`
+	AdminAddr           string        `yaml:"admin_addr"`
 	AgentListenAddr     string        `yaml:"agent_listen_addr"`
 	MaxAgents           int           `yaml:"max_agents"`
 	MaxStreamsPerAgent  int           `yaml:"max_streams_per_agent"`
@@ -38,12 +39,19 @@ type TLSPaths struct {
 	ClientCAFile string `yaml:"client_ca_file"`
 }
 
-// CustomerConfig defines per-customer resource limits and port allowances.
+// CustomerConfig defines per-customer port allocations and resource limits.
 type CustomerConfig struct {
-	CustomerID       string `yaml:"customer_id"`
-	AllowedPorts     []int  `yaml:"allowed_ports"`
-	MaxStreams       int    `yaml:"max_streams"`
-	MaxBandwidthMbps int    `yaml:"max_bandwidth_mbps"`
+	ID               string       `yaml:"id"`
+	Ports            []PortConfig `yaml:"ports"`
+	MaxStreams       int          `yaml:"max_streams"`
+	MaxBandwidthMbps int          `yaml:"max_bandwidth_mbps"`
+}
+
+// PortConfig maps a relay-side port to a named service for a customer.
+type PortConfig struct {
+	Port        int    `yaml:"port"`
+	Service     string `yaml:"service"`
+	Description string `yaml:"description"`
 }
 
 // RelayConnection holds the agent-side settings for connecting to a relay.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -53,6 +53,12 @@ func (l *FileLoader) LoadRelayConfig(path string) (*RelayConfig, error) {
 		return nil, fmt.Errorf("config: parse %s: %w", path, err)
 	}
 
+	l.applyRelayEnvOverrides(&cfg)
+
+	if err := l.validateRelayConfig(&cfg); err != nil {
+		return nil, fmt.Errorf("config: validate: %w", err)
+	}
+
 	return &cfg, nil
 }
 
@@ -91,6 +97,89 @@ func (l *FileLoader) validateAgentConfig(cfg *AgentConfig) error {
 		return fmt.Errorf("tls.ca_file is required")
 	}
 	return nil
+}
+
+// applyRelayEnvOverrides applies environment variable overrides to the
+// relay config.
+func (l *FileLoader) applyRelayEnvOverrides(cfg *RelayConfig) {
+	if v := os.Getenv("ATLAX_LISTEN_ADDR"); v != "" {
+		cfg.Server.ListenAddr = v
+	}
+	if v := os.Getenv("ATLAX_AGENT_LISTEN_ADDR"); v != "" {
+		cfg.Server.AgentListenAddr = v
+	}
+	if v := os.Getenv("ATLAX_TLS_CERT"); v != "" {
+		cfg.TLS.CertFile = v
+	}
+	if v := os.Getenv("ATLAX_TLS_KEY"); v != "" {
+		cfg.TLS.KeyFile = v
+	}
+	if v := os.Getenv("ATLAX_TLS_CA"); v != "" {
+		cfg.TLS.CAFile = v
+	}
+	if v := os.Getenv("ATLAX_TLS_CLIENT_CA"); v != "" {
+		cfg.TLS.ClientCAFile = v
+	}
+	if v := os.Getenv("ATLAX_LOG_LEVEL"); v != "" {
+		cfg.Logging.Level = v
+	}
+}
+
+// validateRelayConfig checks that required fields are present.
+func (l *FileLoader) validateRelayConfig(cfg *RelayConfig) error {
+	if cfg.Server.ListenAddr == "" {
+		return fmt.Errorf("server.listen_addr is required")
+	}
+	if cfg.TLS.CertFile == "" {
+		return fmt.Errorf("tls.cert_file is required")
+	}
+	if cfg.TLS.KeyFile == "" {
+		return fmt.Errorf("tls.key_file is required")
+	}
+	if cfg.TLS.ClientCAFile == "" {
+		return fmt.Errorf("tls.client_ca_file is required")
+	}
+	if len(cfg.Customers) == 0 {
+		return fmt.Errorf("at least one customer must be configured")
+	}
+	for i, c := range cfg.Customers {
+		if c.ID == "" {
+			return fmt.Errorf("customers[%d].id is required", i)
+		}
+	}
+	return nil
+}
+
+// PortIndex is a mapping from relay-side port to customer ID and service
+// name, built from the relay configuration.
+type PortIndex struct {
+	Entries map[int]PortIndexEntry
+}
+
+// PortIndexEntry holds the customer and service for a single port.
+type PortIndexEntry struct {
+	CustomerID string
+	Service    string
+}
+
+// BuildPortIndex creates a port-to-customer-service index from the relay
+// config. Returns an error if any port is assigned to multiple customers.
+func BuildPortIndex(customers []CustomerConfig) (*PortIndex, error) {
+	idx := &PortIndex{Entries: make(map[int]PortIndexEntry)}
+	for _, c := range customers {
+		for _, p := range c.Ports {
+			if existing, ok := idx.Entries[p.Port]; ok {
+				return nil, fmt.Errorf(
+					"port %d assigned to both %s and %s",
+					p.Port, existing.CustomerID, c.ID)
+			}
+			idx.Entries[p.Port] = PortIndexEntry{
+				CustomerID: c.ID,
+				Service:    p.Service,
+			}
+		}
+	}
+	return idx, nil
 }
 
 // DefaultAgentConfig returns an AgentConfig with sensible defaults

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -185,20 +185,167 @@ func TestDefaultAgentConfig(t *testing.T) {
 	assert.Equal(t, "json", cfg.Logging.Format)
 }
 
-func TestLoadRelayConfig_Valid(t *testing.T) {
-	yaml := `
+const validRelayYAML = `
 server:
   listen_addr: ":8443"
+  admin_addr: ":9090"
   agent_listen_addr: ":8444"
+  max_agents: 1000
+  max_streams_per_agent: 100
+  idle_timeout: 300s
+  shutdown_grace_period: 30s
 tls:
   cert_file: /relay.crt
   key_file: /relay.key
+  ca_file: /root-ca.crt
   client_ca_file: /customer-ca.crt
+customers:
+  - id: "customer-dev-001"
+    ports:
+      - port: 8080
+        service: "http"
+        description: "HTTP web service"
+      - port: 8081
+        service: "smb"
+        description: "SMB file sharing"
+logging:
+  level: info
+  format: json
 `
-	path := writeConfig(t, yaml)
+
+func TestLoadRelayConfig_Valid(t *testing.T) {
+	path := writeConfig(t, validRelayYAML)
 	loader := NewFileLoader()
 	cfg, err := loader.LoadRelayConfig(path)
 	require.NoError(t, err)
 	assert.Equal(t, ":8443", cfg.Server.ListenAddr)
+	assert.Equal(t, ":9090", cfg.Server.AdminAddr)
 	assert.Equal(t, "/relay.crt", cfg.TLS.CertFile)
+	assert.Equal(t, "/customer-ca.crt", cfg.TLS.ClientCAFile)
+	require.Len(t, cfg.Customers, 1)
+	assert.Equal(t, "customer-dev-001", cfg.Customers[0].ID)
+	require.Len(t, cfg.Customers[0].Ports, 2)
+	assert.Equal(t, 8080, cfg.Customers[0].Ports[0].Port)
+	assert.Equal(t, "http", cfg.Customers[0].Ports[0].Service)
+}
+
+func TestLoadRelayConfig_MissingListenAddr(t *testing.T) {
+	yml := `
+tls:
+  cert_file: /cert
+  key_file: /key
+  client_ca_file: /ca
+customers:
+  - id: "c1"
+`
+	path := writeConfig(t, yml)
+	loader := NewFileLoader()
+	_, err := loader.LoadRelayConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server.listen_addr is required")
+}
+
+func TestLoadRelayConfig_MissingClientCA(t *testing.T) {
+	yml := `
+server:
+  listen_addr: ":8443"
+tls:
+  cert_file: /cert
+  key_file: /key
+customers:
+  - id: "c1"
+`
+	path := writeConfig(t, yml)
+	loader := NewFileLoader()
+	_, err := loader.LoadRelayConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tls.client_ca_file is required")
+}
+
+func TestLoadRelayConfig_NoCustomers(t *testing.T) {
+	yml := `
+server:
+  listen_addr: ":8443"
+tls:
+  cert_file: /cert
+  key_file: /key
+  client_ca_file: /ca
+customers: []
+`
+	path := writeConfig(t, yml)
+	loader := NewFileLoader()
+	_, err := loader.LoadRelayConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one customer")
+}
+
+func TestLoadRelayConfig_CustomerMissingID(t *testing.T) {
+	yml := `
+server:
+  listen_addr: ":8443"
+tls:
+  cert_file: /cert
+  key_file: /key
+  client_ca_file: /ca
+customers:
+  - ports:
+      - port: 8080
+        service: "http"
+`
+	path := writeConfig(t, yml)
+	loader := NewFileLoader()
+	_, err := loader.LoadRelayConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "customers[0].id is required")
+}
+
+func TestLoadRelayConfig_EnvOverrides(t *testing.T) {
+	path := writeConfig(t, validRelayYAML)
+
+	t.Setenv("ATLAX_LISTEN_ADDR", ":9443")
+	t.Setenv("ATLAX_TLS_CLIENT_CA", "/override/ca.crt")
+	t.Setenv("ATLAX_LOG_LEVEL", "debug")
+
+	loader := NewFileLoader()
+	cfg, err := loader.LoadRelayConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, ":9443", cfg.Server.ListenAddr)
+	assert.Equal(t, "/override/ca.crt", cfg.TLS.ClientCAFile)
+	assert.Equal(t, "debug", cfg.Logging.Level)
+}
+
+func TestBuildPortIndex(t *testing.T) {
+	customers := []CustomerConfig{
+		{
+			ID: "customer-001",
+			Ports: []PortConfig{
+				{Port: 8080, Service: "http"},
+				{Port: 8081, Service: "smb"},
+			},
+		},
+		{
+			ID: "customer-002",
+			Ports: []PortConfig{
+				{Port: 9080, Service: "http"},
+			},
+		},
+	}
+
+	idx, err := BuildPortIndex(customers)
+	require.NoError(t, err)
+	assert.Len(t, idx.Entries, 3)
+	assert.Equal(t, "customer-001", idx.Entries[8080].CustomerID)
+	assert.Equal(t, "http", idx.Entries[8080].Service)
+	assert.Equal(t, "customer-002", idx.Entries[9080].CustomerID)
+}
+
+func TestBuildPortIndex_DuplicatePort(t *testing.T) {
+	customers := []CustomerConfig{
+		{ID: "c1", Ports: []PortConfig{{Port: 8080, Service: "http"}}},
+		{ID: "c2", Ports: []PortConfig{{Port: 8080, Service: "web"}}},
+	}
+
+	_, err := BuildPortIndex(customers)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "port 8080 assigned to both")
 }


### PR DESCRIPTION
## Summary

Phase 3 Step 4: Relay config loader expansion.

- CustomerConfig: `ID` + `Ports[]` (PortConfig with port/service/description) matching relay.example.yaml
- ServerConfig: added `AdminAddr`
- `LoadRelayConfig`: validates required fields, applies env overrides
- `BuildPortIndex`: port-to-customer-service map, detects duplicate ports
- 8 new relay config tests, coverage 92.1%

## Test plan

- [x] Valid relay YAML loads with all fields parsed (customers, ports, TLS)
- [x] Missing listen_addr, client_ca, no customers, customer without ID all rejected
- [x] Env overrides: ATLAX_LISTEN_ADDR, ATLAX_TLS_CLIENT_CA, ATLAX_LOG_LEVEL
- [x] BuildPortIndex maps ports correctly, detects duplicates
- [x] All existing agent config tests still pass
- [ ] CI passes