### PR TITLE
feat(config): per-port ListenAddr + multi-tenancy guide

### DIFF
--- a/configs/relay.example.yaml
+++ b/configs/relay.example.yaml
@@ -41,10 +41,25 @@ tls:
 # Production uses CN=customer-{uuid}; dev uses customer-dev-001.
 customers:
   - id: "customer-dev-001"
+
+    # Maximum concurrent connections from this customer's agents.
+    # Default 1: new agent connection replaces old one with GOAWAY.
+    max_connections: 1
+
+    # Maximum concurrent streams (active client connections forwarded
+    # to this customer). 0 = unlimited.
+    max_streams: 100
+
     ports:
       - port: 8080
         service: "http"
         description: "HTTP web service"
+
+        # Bind address for this port. Default: 0.0.0.0 (all interfaces).
+        # Set to 127.0.0.1 when using a reverse proxy (Caddy/nginx)
+        # so only the proxy can reach the relay port.
+        # listen_addr: "127.0.0.1"
+
       - port: 8081
         service: "smb"
         description: "SMB file sharing"

--- a/docs/development/phase4/step4-config-docs-report.md
+++ b/docs/development/phase4/step4-config-docs-report.md
@@ -1,0 +1,27 @@
+# Step 4 Report: Per-Port ListenAddr + Config + Documentation
+
+**Date:** 2026-04-01
+**Branch:** `phase4/config-docs`
+**PR:** pending
+**Status:** COMPLETED
+
+---
+
+## Summary
+
+Three deliverables:
+
+**Per-port ListenAddr:** `PortConfig.ListenAddr` field (default `0.0.0.0`). Set to `127.0.0.1` for reverse proxy deployments. Carried through `PortIndexEntry` to `Relay.Start` which uses it in the bind address.
+
+**Config updates:** `relay.example.yaml` updated with `max_connections`, `max_streams`, and `listen_addr` per port with documentation comments.
+
+**Multi-tenancy guide:** `docs/operations/multi-tenancy.md` covering isolation model, resource limits, Caddy reverse proxy pattern, metrics, and complete multi-tenant config example.
+
+## Decisions Made
+
+1. **Default 0.0.0.0** -- Backward compatible. Existing configs without `listen_addr` bind to all interfaces (same as before).
+2. **Per-port, not global** -- Each port can have a different bind address. HTTP ports behind Caddy use 127.0.0.1, SMB ports exposed directly use 0.0.0.0.
+
+## Coverage Report
+
+2 new tests: ListenAddr default (0.0.0.0), ListenAddr custom (127.0.0.1).

--- a/docs/operations/multi-tenancy.md
+++ b/docs/operations/multi-tenancy.md
@@ -1,0 +1,167 @@
+# Multi-Tenancy Guide
+
+## Overview
+
+atlax supports multiple customers on a single relay. Each customer gets dedicated TCP ports, isolated stream routing, and configurable resource limits. This document explains the isolation model, configuration, and deployment patterns.
+
+## Isolation Model
+
+Tenant isolation in atlax is **structural**, not policy-based:
+
+1. **Port-to-customer mapping is static.** Each relay port is assigned to exactly one customer in the config. There is no runtime routing decision -- the port determines the customer.
+
+2. **mTLS identity is cryptographic.** The agent's customer ID is extracted from its certificate CN (`customer-{uuid}`). The relay verifies the cert against the Customer Intermediate CA. Forging an identity requires the CA's private key.
+
+3. **No cross-tenant stream routing.** When a client connects on port 18080, the relay looks up which customer owns that port, then opens a stream on that customer's MuxSession. There is no path for traffic on customer-A's port to reach customer-B's agent.
+
+4. **Agent registry is keyed by customer ID.** Each customer has exactly one active agent connection (or N with `max_connections > 1`). A client connection always routes to the registered agent for that customer.
+
+## Resource Limits
+
+### Per-customer stream limits
+
+```yaml
+customers:
+  - id: customer-001
+    max_streams: 100  # 0 = unlimited
+```
+
+When a client connects and the customer's agent already has `max_streams` active streams, the connection is rejected. This prevents a single customer from consuming all relay resources.
+
+### Per-customer connection limits
+
+```yaml
+customers:
+  - id: customer-001
+    max_connections: 1  # default: 1 (replace on reconnect)
+```
+
+With `max_connections: 1` (default), a new agent connection replaces the old one with GOAWAY. This is the expected behavior for single-agent deployments.
+
+### Per-source-IP rate limiting
+
+Rate limiting is applied per source IP at the client listener level. All customer ports share a single rate limiter. Configuration is done at the relay startup level (not per-customer in the current version).
+
+When a source IP exceeds the rate limit, connections are rejected immediately (TCP close).
+
+## Per-Port Bind Address
+
+By default, customer ports bind to `0.0.0.0` (all interfaces). For reverse proxy deployments, bind to `127.0.0.1` so only the local proxy can reach the relay port:
+
+```yaml
+customers:
+  - id: customer-001
+    ports:
+      - port: 18080
+        service: http
+        listen_addr: 127.0.0.1  # only Caddy/nginx can reach this
+```
+
+### Caddy Reverse Proxy Pattern
+
+The recommended production topology for HTTP services:
+
+```
+Internet -> Caddy (port 443, TLS, subdomain routing)
+              |
+              +-> 127.0.0.1:18080 -> atlax relay -> tunnel -> agent -> web app
+              +-> 127.0.0.1:18070 -> atlax relay -> tunnel -> agent -> API
+```
+
+Caddy provides:
+- TLS termination (HTTPS on the public edge)
+- Subdomain routing (`app.example.com` -> port 18080, `api.example.com` -> port 18070)
+- HTTP-level rate limiting, caching, and headers
+- Automatic certificate management (Let's Encrypt)
+
+The atlax relay provides:
+- mTLS tunnel to the agent (encrypted transport)
+- Stream multiplexing (many clients over one tunnel)
+- Per-customer isolation and resource limits
+
+Example Caddyfile:
+
+```
+app.example.com {
+    reverse_proxy 127.0.0.1:18080
+}
+
+api.example.com {
+    reverse_proxy 127.0.0.1:18070
+}
+```
+
+With `listen_addr: 127.0.0.1` on the relay ports, the customer ports are not accessible from the internet even if the firewall is misconfigured. Defense in depth.
+
+### Non-HTTP Services (SMB, raw TCP)
+
+For non-HTTP protocols, Caddy cannot help (it does not proxy raw TCP by default). These ports must be exposed directly:
+
+```yaml
+ports:
+  - port: 18445
+    service: smb
+    # listen_addr defaults to 0.0.0.0 (direct exposure)
+```
+
+Use AWS security group rules to restrict source IPs for non-HTTP ports.
+
+## Prometheus Metrics
+
+Per-customer metrics are available when Prometheus is configured:
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `atlax_streams_total` | Counter | customer_id | Total streams opened |
+| `atlax_streams_active` | Gauge | customer_id | Currently active streams |
+| `atlax_connections_total` | Counter | customer_id | Total agent connections |
+| `atlax_connections_active` | Gauge | customer_id | Currently connected agents |
+| `atlax_clients_rejected_total` | Counter | customer_id, reason | Rejected client connections |
+
+Rejection reasons: `rate_limited`, `stream_limit`, `no_agent`.
+
+## Configuration Example
+
+Complete multi-tenant relay config:
+
+```yaml
+server:
+  listen_addr: 0.0.0.0:8443
+  admin_addr: 127.0.0.1:9090
+  max_agents: 100
+  idle_timeout: 300s
+  shutdown_grace_period: 30s
+
+tls:
+  cert_file: /etc/atlax/certs/relay.crt
+  key_file: /etc/atlax/certs/relay.key
+  ca_file: /etc/atlax/certs/root-ca.crt
+  client_ca_file: /etc/atlax/certs/customer-ca.crt
+
+customers:
+  - id: customer-acme
+    max_connections: 1
+    max_streams: 50
+    ports:
+      - port: 18080
+        service: http
+        listen_addr: 127.0.0.1
+      - port: 18070
+        service: api
+        listen_addr: 127.0.0.1
+
+  - id: customer-globex
+    max_connections: 1
+    max_streams: 100
+    ports:
+      - port: 19080
+        service: http
+        listen_addr: 127.0.0.1
+      - port: 19445
+        service: smb
+        # Direct exposure for SMB (no reverse proxy)
+
+logging:
+  level: info
+  format: json
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,7 @@ type PortConfig struct {
 	Port        int    `yaml:"port"`
 	Service     string `yaml:"service"`
 	Description string `yaml:"description"`
+	ListenAddr  string `yaml:"listen_addr"` // default: 0.0.0.0 (all interfaces)
 }
 
 // RelayConnection holds the agent-side settings for connecting to a relay.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -156,11 +156,13 @@ type PortIndex struct {
 	Entries map[int]PortIndexEntry
 }
 
-// PortIndexEntry holds the customer, service, and limits for a single port.
+// PortIndexEntry holds the customer, service, limits, and bind address
+// for a single port.
 type PortIndexEntry struct {
 	CustomerID string
 	Service    string
 	MaxStreams int
+	ListenAddr string // default: "0.0.0.0"
 }
 
 // BuildPortIndex creates a port-to-customer-service index from the relay
@@ -174,10 +176,15 @@ func BuildPortIndex(customers []CustomerConfig) (*PortIndex, error) {
 					"port %d assigned to both %s and %s",
 					p.Port, existing.CustomerID, c.ID)
 			}
+			listenAddr := p.ListenAddr
+			if listenAddr == "" {
+				listenAddr = "0.0.0.0"
+			}
 			idx.Entries[p.Port] = PortIndexEntry{
 				CustomerID: c.ID,
 				Service:    p.Service,
 				MaxStreams: c.MaxStreams,
+				ListenAddr: listenAddr,
 			}
 		}
 	}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -349,3 +349,29 @@ func TestBuildPortIndex_DuplicatePort(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "port 8080 assigned to both")
 }
+
+func TestBuildPortIndex_ListenAddrDefault(t *testing.T) {
+	customers := []CustomerConfig{
+		{
+			ID:    "c1",
+			Ports: []PortConfig{{Port: 8080, Service: "http"}},
+		},
+	}
+	idx, err := BuildPortIndex(customers)
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0", idx.Entries[8080].ListenAddr)
+}
+
+func TestBuildPortIndex_ListenAddrCustom(t *testing.T) {
+	customers := []CustomerConfig{
+		{
+			ID: "c1",
+			Ports: []PortConfig{
+				{Port: 8080, Service: "http", ListenAddr: "127.0.0.1"},
+			},
+		},
+	}
+	idx, err := BuildPortIndex(customers)
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", idx.Entries[8080].ListenAddr)
+}

--- a/pkg/relay/server_impl.go
+++ b/pkg/relay/server_impl.go
@@ -58,8 +58,8 @@ func (s *Relay) Start(ctx context.Context) error {
 	}
 
 	// Start per-port client listeners.
-	for port := range s.portIndex.Entries {
-		addr := fmt.Sprintf(":%d", port)
+	for port, entry := range s.portIndex.Entries {
+		addr := fmt.Sprintf("%s:%d", entry.ListenAddr, port)
 		go func(a string, p int) {
 			if err := s.clientListener.StartPort(ctx, a, p); err != nil {
 				s.logger.Error("relay: client listener failed",


### PR DESCRIPTION
## Summary

Phase 4 Step 4: Deployment knob for reverse proxy setups + documentation.

**Per-port ListenAddr:**
- `PortConfig.ListenAddr` (default `0.0.0.0`)
- Set `127.0.0.1` to bind customer ports to loopback behind Caddy/nginx
- Carried through PortIndexEntry to Relay.Start

**Config updates:**
- `relay.example.yaml` with max_connections, max_streams, listen_addr

**Multi-tenancy guide** (`docs/operations/multi-tenancy.md`):
- Isolation model (structural, not policy)
- Resource limits (streams, connections, rate limiting)
- Caddy reverse proxy pattern with example Caddyfile
- Prometheus metrics table
- Complete multi-tenant config example

## Test plan

- [x] ListenAddr defaults to 0.0.0.0 when not set
- [x] ListenAddr carries custom value (127.0.0.1) through config
- [x] All existing tests pass
- [ ] CI passes