### PR TITLE
feat(agent): idle timeout closes stale forwarding sessions

### DIFF
--- a/docs/development/phase5/step3-idle-timeout-report.md
+++ b/docs/development/phase5/step3-idle-timeout-report.md
@@ -1,0 +1,27 @@
+# Step 3 Report: IdleTimeout for Forwarder
+
+**Date:** 2026-04-02
+**Branch:** `phase5/idle-timeout`
+**PR:** pending
+**Status:** COMPLETED
+
+---
+
+## Summary
+
+Idle forwarding sessions are now closed after a configurable timeout. The `idleConn` wrapper resets the read/write deadline on every operation. If no data flows for `IdleTimeout`, the deadline fires and the connection closes.
+
+**Changes:**
+- `idleConn`: wraps net.Conn, calls SetDeadline before every Read/Write
+- `newIdleConn(conn, timeout)`: returns original conn if timeout is 0 (backward compatible)
+- `Forwarder.Forward`: wraps the local TCP connection with idleConn
+
+## Decisions Made
+
+1. **Explicit net.Conn implementation (not embedded)** -- Used explicit `conn` field instead of `net.Conn` embedding to avoid staticcheck QF1008 and prevent recursive method calls. All net.Conn methods delegated explicitly.
+2. **Deadline on both Read and Write** -- Any data transfer resets the deadline. An idle session means no reads AND no writes.
+3. **Zero timeout = disabled** -- `newIdleConn` returns the original conn unchanged. Existing configs without IdleTimeout work as before.
+
+## Coverage Report
+
+4 new tests: timeout on idle, active connection stays open, write resets deadline, zero timeout passthrough.

--- a/pkg/agent/forwarder_impl.go
+++ b/pkg/agent/forwarder_impl.go
@@ -43,10 +43,11 @@ func (f *Forwarder) Forward(
 	target string,
 ) error {
 	dialer := &net.Dialer{Timeout: f.config.DialTimeout}
-	local, err := dialer.DialContext(ctx, "tcp", target)
+	rawLocal, err := dialer.DialContext(ctx, "tcp", target)
 	if err != nil {
 		return fmt.Errorf("forwarder: dial %s: %w", target, err)
 	}
+	local := newIdleConn(rawLocal, f.config.IdleTimeout)
 
 	var wg sync.WaitGroup
 	var firstErr error
@@ -80,7 +81,7 @@ func (f *Forwarder) Forward(
 			setErr(cpErr)
 		}
 		// Half-close the write side to signal EOF to the local service.
-		if tc, ok := local.(*net.TCPConn); ok {
+		if tc, ok := rawLocal.(*net.TCPConn); ok {
 			tc.CloseWrite() //nolint:errcheck // best-effort half-close
 		}
 	}()

--- a/pkg/agent/idleconn.go
+++ b/pkg/agent/idleconn.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"net"
+	"time"
+)
+
+// idleConn wraps a net.Conn and resets the read/write deadline on every
+// successful operation. If no data flows for the configured timeout,
+// the deadline fires and the next Read/Write returns an error.
+type idleConn struct {
+	conn    net.Conn
+	timeout time.Duration
+}
+
+// newIdleConn wraps conn with idle timeout. If timeout is 0, returns
+// conn unchanged.
+func newIdleConn(conn net.Conn, timeout time.Duration) net.Conn {
+	if timeout <= 0 {
+		return conn
+	}
+	return &idleConn{conn: conn, timeout: timeout}
+}
+
+func (c *idleConn) Read(p []byte) (int, error) {
+	if err := c.conn.SetDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, err
+	}
+	return c.conn.Read(p)
+}
+
+func (c *idleConn) Write(p []byte) (int, error) {
+	if err := c.conn.SetDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, err
+	}
+	return c.conn.Write(p)
+}
+
+func (c *idleConn) Close() error                       { return c.conn.Close() }
+func (c *idleConn) LocalAddr() net.Addr                { return c.conn.LocalAddr() }
+func (c *idleConn) RemoteAddr() net.Addr               { return c.conn.RemoteAddr() }
+func (c *idleConn) SetDeadline(t time.Time) error      { return c.conn.SetDeadline(t) }
+func (c *idleConn) SetReadDeadline(t time.Time) error  { return c.conn.SetReadDeadline(t) }
+func (c *idleConn) SetWriteDeadline(t time.Time) error { return c.conn.SetWriteDeadline(t) }

--- a/pkg/agent/idleconn_test.go
+++ b/pkg/agent/idleconn_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleConn_TimeoutOnIdle(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+
+	ic := newIdleConn(c1, 50*time.Millisecond)
+
+	// No data written to c2, so Read should timeout
+	buf := make([]byte, 10)
+	_, err := ic.Read(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestIdleConn_ActiveConnectionStaysOpen(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	ic := newIdleConn(c1, 200*time.Millisecond)
+
+	// Write data from c2 before timeout
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		c2.Write([]byte("hello")) //nolint:errcheck // test
+	}()
+
+	buf := make([]byte, 10)
+	n, err := ic.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(buf[:n]))
+}
+
+func TestIdleConn_WriteResetsDeadline(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+
+	ic := newIdleConn(c1, 200*time.Millisecond)
+
+	// Read from c2 in background to unblock Write
+	go func() {
+		buf := make([]byte, 64)
+		c2.Read(buf) //nolint:errcheck // test
+	}()
+
+	_, err := ic.Write([]byte("data"))
+	require.NoError(t, err)
+}
+
+func TestIdleConn_ZeroTimeoutPassthrough(t *testing.T) {
+	c1, _ := net.Pipe()
+	defer c1.Close()
+
+	// Zero timeout should return the original conn, not wrapped
+	result := newIdleConn(c1, 0)
+	assert.Equal(t, c1, result, "zero timeout should return original conn")
+}


### PR DESCRIPTION
## Summary

Phase 5 Step 3: Idle forwarding sessions closed after configurable timeout.

`idleConn` wraps `net.Conn` with `SetDeadline` on every Read/Write. No data for `IdleTimeout` = deadline fires = connection closes. Zero timeout = disabled (backward compatible).

Closes #34.

## Test plan

- [x] Idle connection times out and returns error
- [x] Active connection stays open (deadline resets)
- [x] Write resets deadline
- [x] Zero timeout returns original conn unchanged
- [x] All existing tests pass
- [x] CI passes