### PR TITLE
feat(relay): per-customer rate limits, Prometheus guide, Grafana dashboard, alerting

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -83,6 +83,13 @@ func run() error {
 	router.SetMetrics(metrics)
 	clientListener := relay.NewClientListener(relay.ClientListenerConfig{Router: router, Logger: logger})
 
+	// Configure per-customer rate limiters from YAML config.
+	for _, c := range cfg.Customers {
+		if c.RateLimit.RequestsPerSecond > 0 {
+			clientListener.SetRateLimiter(c.ID, c.RateLimit.RequestsPerSecond, c.RateLimit.Burst)
+		}
+	}
+
 	server := relay.NewRelay(relay.ServerDeps{
 		AgentListener:  agentListener,
 		ClientListener: clientListener,

--- a/deployments/grafana/relay-dashboard.json
+++ b/deployments/grafana/relay-dashboard.json
@@ -1,0 +1,75 @@
+{
+  "dashboard": {
+    "title": "atlax Relay",
+    "uid": "atlax-relay",
+    "tags": ["atlax", "relay", "tunnel"],
+    "timezone": "browser",
+    "refresh": "10s",
+    "panels": [
+      {
+        "title": "Active Agents",
+        "type": "stat",
+        "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+        "targets": [
+          {"expr": "sum(atlax_connections_active)", "legendFormat": "agents"}
+        ]
+      },
+      {
+        "title": "Active Streams",
+        "type": "stat",
+        "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+        "targets": [
+          {"expr": "sum(atlax_streams_active)", "legendFormat": "streams"}
+        ]
+      },
+      {
+        "title": "Rejection Rate",
+        "type": "stat",
+        "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+        "targets": [
+          {"expr": "sum(rate(atlax_clients_rejected_total[5m]))", "legendFormat": "rejected/sec"}
+        ]
+      },
+      {
+        "title": "Total Streams (all time)",
+        "type": "stat",
+        "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+        "targets": [
+          {"expr": "sum(atlax_streams_total)", "legendFormat": "total"}
+        ]
+      },
+      {
+        "title": "Active Streams per Customer",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+        "targets": [
+          {"expr": "atlax_streams_active", "legendFormat": "{{ customer_id }}"}
+        ]
+      },
+      {
+        "title": "Stream Open Rate per Customer",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+        "targets": [
+          {"expr": "rate(atlax_streams_total[5m])", "legendFormat": "{{ customer_id }}"}
+        ]
+      },
+      {
+        "title": "Agent Connections per Customer",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+        "targets": [
+          {"expr": "atlax_connections_active", "legendFormat": "{{ customer_id }}"}
+        ]
+      },
+      {
+        "title": "Client Rejections by Reason",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+        "targets": [
+          {"expr": "rate(atlax_clients_rejected_total[5m])", "legendFormat": "{{ customer_id }} ({{ reason }})"}
+        ]
+      }
+    ]
+  }
+}

--- a/deployments/prometheus/alerts.yml
+++ b/deployments/prometheus/alerts.yml
@@ -1,0 +1,47 @@
+groups:
+  - name: atlax-relay
+    rules:
+      - alert: AgentDisconnected
+        expr: atlax_connections_active == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No agents connected to relay"
+          description: "All agents have been disconnected for more than 2 minutes."
+
+      - alert: AgentDown
+        expr: changes(atlax_connections_active[5m]) > 3
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent connection flapping for {{ $labels.customer_id }}"
+          description: "Agent for {{ $labels.customer_id }} has reconnected {{ $value }} times in 5 minutes."
+
+      - alert: HighRejectionRate
+        expr: rate(atlax_clients_rejected_total[5m]) > 10
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High client rejection rate for {{ $labels.customer_id }}"
+          description: "{{ $labels.customer_id }} rejecting {{ $value }}/sec (reason: {{ $labels.reason }})."
+
+      - alert: StreamLimitApproaching
+        expr: atlax_streams_active / on(customer_id) group_left atlax_streams_active > 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Stream limit approaching for {{ $labels.customer_id }}"
+          description: "{{ $labels.customer_id }} at {{ $value | humanizePercentage }} of stream capacity."
+
+      - alert: RelayDown
+        expr: up{job="atlax-relay"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "atlax relay is unreachable"
+          description: "Prometheus cannot scrape the relay metrics endpoint."

--- a/docs/development/phase6/step2-monitoring-report.md
+++ b/docs/development/phase6/step2-monitoring-report.md
@@ -1,0 +1,24 @@
+# Step 2 Report: Monitoring Stack
+
+**Date:** 2026-04-02
+**Branch:** `phase6/monitoring`
+**PR:** pending
+**Status:** COMPLETED
+
+---
+
+## Summary
+
+**Per-customer rate limiting from YAML config:** ClientListener now uses per-customer IPRateLimiters built from `CustomerConfig.RateLimit`. The old global `RateLimiter` field is replaced with a `rateLimiters map[string]*IPRateLimiter` and `SetRateLimiter(customerID, rps, burst)`. cmd/relay wires from config at startup.
+
+**Prometheus guide:** `docs/operations/prometheus.md` -- scrape config, available metrics, useful PromQL queries, retention, health check.
+
+**Grafana dashboard:** `deployments/grafana/relay-dashboard.json` -- 8 panels: active agents, active streams, rejection rate, stream totals, per-customer streams, open rate, connections, rejections by reason.
+
+**Alerting rules:** `deployments/prometheus/alerts.yml` -- 5 rules: AgentDisconnected, AgentDown (flapping), HighRejectionRate, StreamLimitApproaching, RelayDown.
+
+## Decisions Made
+
+1. **Per-customer map, not global limiter** -- Each customer can have different rate limits. Customers without `rate_limit` in config have no limiting.
+2. **SetRateLimiter called at startup** -- cmd/relay iterates customers and configures limiters before server start. Runtime changes require relay restart (or future admin API).
+3. **PortIndexEntry carries RateLimit** -- Available during routing for future per-port rate limit granularity.

--- a/docs/operations/prometheus.md
+++ b/docs/operations/prometheus.md
@@ -1,0 +1,110 @@
+# Prometheus Monitoring Guide
+
+## Overview
+
+The atlax relay exposes Prometheus metrics on the admin port (default `:9090`) at the `/metrics` endpoint. Metrics are per-customer, enabling multi-tenant monitoring from a single relay.
+
+## Setup
+
+### 1. Verify the relay exposes metrics
+
+```bash
+curl http://localhost:9090/metrics | grep atlax
+```
+
+You should see counters and gauges prefixed with `atlax_`.
+
+### 2. Configure Prometheus scrape
+
+Add to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: atlax-relay
+    scrape_interval: 15s
+    static_configs:
+      - targets:
+          - relay.example.com:9090
+    # If admin port is only on localhost (behind Caddy):
+    # Use SSH tunnel or run Prometheus on the same host
+```
+
+For relays with `admin_addr: 127.0.0.1:9090`, Prometheus must run on the same host or you need an SSH tunnel:
+
+```bash
+ssh -L 9090:127.0.0.1:9090 user@relay.example.com
+```
+
+### 3. Verify scraping
+
+Open Prometheus UI (default `http://localhost:9090`) and query:
+
+```promql
+atlax_streams_active
+```
+
+## Available Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `atlax_streams_total` | Counter | customer_id | Total streams opened |
+| `atlax_streams_active` | Gauge | customer_id | Currently active streams |
+| `atlax_connections_total` | Counter | customer_id | Total agent connections |
+| `atlax_connections_active` | Gauge | customer_id | Currently connected agents |
+| `atlax_clients_rejected_total` | Counter | customer_id, reason | Rejected client connections |
+
+Rejection reasons: `rate_limited`, `stream_limit`, `no_agent`.
+
+## Useful Queries
+
+### Active streams per customer
+
+```promql
+atlax_streams_active
+```
+
+### Stream open rate (per second)
+
+```promql
+rate(atlax_streams_total[5m])
+```
+
+### Rejection rate by reason
+
+```promql
+rate(atlax_clients_rejected_total[5m])
+```
+
+### Total connected agents
+
+```promql
+sum(atlax_connections_active)
+```
+
+### Customer with most active streams
+
+```promql
+topk(5, atlax_streams_active)
+```
+
+## Retention
+
+For a single relay with 10 customers, metrics volume is minimal. Default Prometheus retention (15 days) is sufficient. For longer history, configure:
+
+```yaml
+# prometheus.yml
+storage:
+  tsdb:
+    retention.time: 90d
+```
+
+## Health Check
+
+The relay also exposes `/healthz` on the admin port:
+
+```bash
+curl http://localhost:9090/healthz
+# {"status":"ok","agents":3,"streams":42}
+```
+
+Use this for load balancer health checks and uptime monitoring.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -156,13 +156,14 @@ type PortIndex struct {
 	Entries map[int]PortIndexEntry
 }
 
-// PortIndexEntry holds the customer, service, limits, and bind address
-// for a single port.
+// PortIndexEntry holds the customer, service, limits, bind address,
+// and rate limit config for a single port.
 type PortIndexEntry struct {
 	CustomerID string
 	Service    string
 	MaxStreams int
 	ListenAddr string // default: "0.0.0.0"
+	RateLimit  RateLimitConfig
 }
 
 // BuildPortIndex creates a port-to-customer-service index from the relay
@@ -185,6 +186,7 @@ func BuildPortIndex(customers []CustomerConfig) (*PortIndex, error) {
 				Service:    p.Service,
 				MaxStreams: c.MaxStreams,
 				ListenAddr: listenAddr,
+				RateLimit:  c.RateLimit,
 			}
 		}
 	}

--- a/pkg/relay/client_listener.go
+++ b/pkg/relay/client_listener.go
@@ -11,29 +11,38 @@ import (
 // ClientListener accepts plain TCP connections on per-customer dedicated
 // ports and routes them through the TrafficRouter to the correct agent.
 type ClientListener struct {
-	router      *PortRouter
-	logger      *slog.Logger
-	rateLimiter *IPRateLimiter
-	listeners   map[int]net.Listener
+	router       *PortRouter
+	logger       *slog.Logger
+	rateLimiters map[string]*IPRateLimiter // customerID -> limiter
+	listeners    map[int]net.Listener
 
 	mu sync.Mutex
 }
 
 // ClientListenerConfig holds settings for the client listener.
 type ClientListenerConfig struct {
-	Router      *PortRouter
-	Logger      *slog.Logger
-	RateLimiter *IPRateLimiter // nil = no rate limiting
+	Router *PortRouter
+	Logger *slog.Logger
 }
 
 // NewClientListener creates a client listener.
 func NewClientListener(cfg ClientListenerConfig) *ClientListener {
 	return &ClientListener{
-		router:      cfg.Router,
-		logger:      cfg.Logger,
-		rateLimiter: cfg.RateLimiter,
-		listeners:   make(map[int]net.Listener),
+		router:       cfg.Router,
+		logger:       cfg.Logger,
+		rateLimiters: make(map[string]*IPRateLimiter),
+		listeners:    make(map[int]net.Listener),
 	}
+}
+
+// SetRateLimiter configures a per-customer rate limiter.
+func (cl *ClientListener) SetRateLimiter(customerID string, rps float64, burst int) {
+	if rps <= 0 {
+		return
+	}
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	cl.rateLimiters[customerID] = NewIPRateLimiter(rps, burst)
 }
 
 // StartPort opens a TCP listener on the given address and routes all
@@ -93,13 +102,17 @@ func (cl *ClientListener) handleClient(
 		return
 	}
 
-	// Rate limit by source IP.
-	if cl.rateLimiter != nil {
+	// Rate limit by source IP (per-customer limiter).
+	cl.mu.Lock()
+	rl := cl.rateLimiters[customerID]
+	cl.mu.Unlock()
+
+	if rl != nil {
 		ip, _, splitErr := net.SplitHostPort(conn.RemoteAddr().String())
 		if splitErr != nil {
 			ip = conn.RemoteAddr().String()
 		}
-		if !cl.rateLimiter.Allow(ip) {
+		if !rl.Allow(ip) {
 			if cl.router.metrics != nil {
 				cl.router.metrics.ClientRejected(customerID, "rate_limited")
 			}
@@ -131,9 +144,10 @@ func (cl *ClientListener) Stop() {
 	}
 	cl.listeners = make(map[int]net.Listener)
 
-	if cl.rateLimiter != nil {
-		cl.rateLimiter.Stop()
+	for _, rl := range cl.rateLimiters {
+		rl.Stop()
 	}
+	cl.rateLimiters = make(map[string]*IPRateLimiter)
 }
 
 // Addr returns the listening address for the given port, or nil.


### PR DESCRIPTION
## Summary

Phase 6 Step 2: Full monitoring stack.

**Per-customer rate limiting from YAML:**
- `ClientListener` uses per-customer `IPRateLimiter` map
- `SetRateLimiter(customerID, rps, burst)` called at startup from config
- Customers without `rate_limit` have no limiting

**Prometheus guide** (`docs/operations/prometheus.md`):
- Scrape config, metrics reference, PromQL queries, retention

**Grafana dashboard** (`deployments/grafana/relay-dashboard.json`):
- 8 panels: agents, streams, rejections, per-customer breakdowns

**Alerting rules** (`deployments/prometheus/alerts.yml`):
- AgentDisconnected, AgentDown (flapping), HighRejectionRate, StreamLimitApproaching, RelayDown

Closes #67, #68, #70, #71.

## Test plan

- [x] All existing tests pass (per-customer limiter backward compatible)
- [x] Build clean, lint clean
- [ ] CI passes