### PR TITLE
feat(relay): full CRUD admin API on unix socket

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -111,15 +111,20 @@ func run() error {
 		Timestamp: time.Now(),
 	})
 
-	// Start admin server (health check + metrics)
-	if cfg.Server.AdminAddr != "" {
-		admin := relay.NewAdminServer(cfg.Server.AdminAddr, registry, logger)
-		go func() {
-			if adminErr := admin.Start(ctx); adminErr != nil {
-				logger.Error("admin server error", "error", adminErr)
-			}
-		}()
-	}
+	// Start admin server (health check + metrics + CRUD API)
+	admin := relay.NewAdminServer(relay.AdminConfig{
+		Addr:           cfg.Server.AdminAddr,
+		SocketPath:     "/var/run/atlax.sock",
+		Registry:       registry,
+		Router:         router,
+		ClientListener: clientListener,
+		Logger:         logger,
+	})
+	go func() {
+		if adminErr := admin.Start(ctx); adminErr != nil {
+			logger.Error("admin server error", "error", adminErr)
+		}
+	}()
 
 	serverDone := make(chan error, 1)
 	go func() {

--- a/docs/development/phase6/step4-admin-api-report.md
+++ b/docs/development/phase6/step4-admin-api-report.md
@@ -1,0 +1,41 @@
+# Step 4 Report: Admin API
+
+**Date:** 2026-04-03
+**Branch:** `phase6/admin-api`
+**PR:** pending
+**Status:** COMPLETED
+
+---
+
+## Summary
+
+Full CRUD admin API on unix domain socket + optional TCP. Both community and enterprise editions get the same endpoints.
+
+**Endpoints:**
+- `GET /healthz` -- health check (existed)
+- `GET /metrics` -- Prometheus metrics (existed)
+- `GET /ports` -- list port-to-customer mappings
+- `POST /ports` -- add mapping at runtime (no restart)
+- `DELETE /ports/{port}` -- remove mapping
+- `GET /agents` -- list connected agents with metadata
+- `DELETE /agents/{customerID}` -- disconnect agent (GOAWAY + unregister)
+- `GET /stats` -- relay uptime, agent count, stream count
+
+**Transport:**
+- Unix socket: `/var/run/atlax.sock` (permissions 0660, local access only)
+- TCP: `admin_addr` from config (optional, for remote access)
+- Both can run simultaneously
+
+**Persistence:** Ephemeral. Runtime changes lost on restart. Config file is source of truth.
+
+## Design Decisions
+
+1. **Unix socket for community, TCP for enterprise** -- Socket needs no auth (file permissions). TCP needs bearer token (future enterprise feature).
+2. **Full CRUD for both editions** -- Gating write operations behind enterprise makes community feel broken. Enterprise moat is distributed infra (multi-relay, fleet management), not single-node CRUD.
+3. **writeError helper** -- Consistent JSON error responses via helper function instead of inline fmt.Sprintf.
+4. **AdminConfig struct** -- Replaces the old positional constructor. Carries router and client listener references for CRUD operations.
+5. **ats integration (future)** -- The `ats` CLI tool will detect the socket and use it for operations instead of file editing.
+
+## Coverage Report
+
+11 tests: health, metrics, stats, list ports, create port, invalid JSON, missing fields, delete port, delete port not found, list agents, delete agent.

--- a/pkg/relay/admin.go
+++ b/pkg/relay/admin.go
@@ -3,18 +3,44 @@ package relay
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// AdminServer serves health check and Prometheus metrics endpoints.
+// AdminServer serves the admin API: health check, Prometheus metrics,
+// and CRUD operations for ports, agents, and stats.
 type AdminServer struct {
-	registry AgentRegistry
-	logger   *slog.Logger
-	server   *http.Server
+	registry       AgentRegistry
+	router         *PortRouter
+	clientListener *ClientListener
+	logger         *slog.Logger
+	server         *http.Server
+	socketPath     string
+	startTime      time.Time
+}
+
+// AdminConfig holds settings for the admin server.
+type AdminConfig struct {
+	// Addr is the TCP address (e.g., "127.0.0.1:9090"). If empty and
+	// SocketPath is set, only the unix socket is used.
+	Addr string
+
+	// SocketPath is the unix domain socket path (e.g., "/var/run/atlax.sock").
+	// If empty, only TCP is used.
+	SocketPath string
+
+	Registry       AgentRegistry
+	Router         *PortRouter
+	ClientListener *ClientListener
+	Logger         *slog.Logger
 }
 
 // HealthResponse is the JSON body returned by /healthz.
@@ -24,38 +50,123 @@ type HealthResponse struct {
 	Streams int    `json:"streams"`
 }
 
-// NewAdminServer creates an admin HTTP server on the given address.
-func NewAdminServer(addr string, registry AgentRegistry, logger *slog.Logger) *AdminServer {
+// StatsResponse is the JSON body returned by /stats.
+type StatsResponse struct {
+	Status        string  `json:"status"`
+	Uptime        string  `json:"uptime"`
+	UptimeSeconds float64 `json:"uptime_seconds"`
+	Agents        int     `json:"agents"`
+	Streams       int     `json:"streams"`
+}
+
+// PortResponse represents a single port mapping in API responses.
+type PortResponse struct {
+	Port       int    `json:"port"`
+	CustomerID string `json:"customer_id"`
+	Service    string `json:"service"`
+}
+
+// AgentResponse represents a connected agent in API responses.
+type AgentResponse struct {
+	CustomerID  string `json:"customer_id"`
+	RemoteAddr  string `json:"remote_addr"`
+	ConnectedAt string `json:"connected_at"`
+	LastSeen    string `json:"last_seen"`
+	StreamCount int    `json:"stream_count"`
+}
+
+// PortCreateRequest is the JSON body for POST /ports.
+type PortCreateRequest struct {
+	Port       int    `json:"port"`
+	CustomerID string `json:"customer_id"`
+	Service    string `json:"service"`
+	MaxStreams int    `json:"max_streams"`
+}
+
+// NewAdminServer creates an admin server with the full API.
+func NewAdminServer(cfg AdminConfig) *AdminServer {
 	a := &AdminServer{
-		registry: registry,
-		logger:   logger,
+		registry:       cfg.Registry,
+		router:         cfg.Router,
+		clientListener: cfg.ClientListener,
+		logger:         cfg.Logger,
+		socketPath:     cfg.SocketPath,
+		startTime:      time.Now(),
 	}
 
 	mux := http.NewServeMux()
+
+	// Existing endpoints
 	mux.HandleFunc("/healthz", a.handleHealth)
 	mux.Handle("/metrics", promhttp.Handler())
 
+	// CRUD endpoints
+	mux.HandleFunc("/ports", a.handlePorts)
+	mux.HandleFunc("/ports/", a.handlePortByID)
+	mux.HandleFunc("/agents", a.handleAgents)
+	mux.HandleFunc("/agents/", a.handleAgentByID)
+	mux.HandleFunc("/stats", a.handleStats)
+
 	a.server = &http.Server{
-		Addr:              addr,
+		Addr:              cfg.Addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	return a
 }
 
-// Start begins serving. Blocks until ctx is canceled.
+// Start begins serving on TCP and/or unix socket. Blocks until ctx is canceled.
 func (a *AdminServer) Start(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
 		a.server.Close()
+		if a.socketPath != "" {
+			os.Remove(a.socketPath)
+		}
 	}()
 
-	a.logger.Info("relay: admin server started", "addr", a.server.Addr)
-	if err := a.server.ListenAndServe(); err != http.ErrServerClosed {
+	// Unix socket listener
+	if a.socketPath != "" {
+		os.Remove(a.socketPath) // clean up stale socket
+		unixLn, err := net.Listen("unix", a.socketPath)
+		if err != nil {
+			return fmt.Errorf("admin: unix socket: %w", err)
+		}
+		os.Chmod(a.socketPath, 0o660) //nolint:errcheck // best-effort permissions
+
+		a.logger.Info("relay: admin socket started", "path", a.socketPath)
+
+		if a.server.Addr == "" {
+			// Socket only, no TCP
+			return a.serve(unixLn)
+		}
+
+		// Both socket and TCP
+		go func() {
+			if err := a.serve(unixLn); err != nil {
+				a.logger.Error("admin: unix socket error", "error", err)
+			}
+		}()
+	}
+
+	// TCP listener
+	if a.server.Addr != "" {
+		a.logger.Info("relay: admin server started", "addr", a.server.Addr)
+		if err := a.server.ListenAndServe(); err != http.ErrServerClosed {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *AdminServer) serve(ln net.Listener) error {
+	if err := a.server.Serve(ln); err != http.ErrServerClosed {
 		return err
 	}
 	return nil
 }
+
+// --- Health ---
 
 func (a *AdminServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 	agents, err := a.registry.ListConnectedAgents(r.Context())
@@ -69,12 +180,194 @@ func (a *AdminServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 		totalStreams += agent.StreamCount
 	}
 
-	resp := HealthResponse{
+	writeJSON(w, HealthResponse{
 		Status:  "ok",
 		Agents:  len(agents),
 		Streams: totalStreams,
+	})
+}
+
+// --- Stats ---
+
+func (a *AdminServer) handleStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
 	}
 
+	agents, err := a.registry.ListConnectedAgents(r.Context())
+	if err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
+
+	totalStreams := 0
+	for _, agent := range agents {
+		totalStreams += agent.StreamCount
+	}
+
+	uptime := time.Since(a.startTime)
+	writeJSON(w, StatsResponse{
+		Status:        "ok",
+		Uptime:        uptime.Round(time.Second).String(),
+		UptimeSeconds: uptime.Seconds(),
+		Agents:        len(agents),
+		Streams:       totalStreams,
+	})
+}
+
+// --- Ports ---
+
+func (a *AdminServer) handlePorts(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		a.listPorts(w, r)
+	case http.MethodPost:
+		a.createPort(w, r)
+	default:
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *AdminServer) handlePortByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	portStr := strings.TrimPrefix(r.URL.Path, "/ports/")
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid port number"}`, http.StatusBadRequest)
+		return
+	}
+
+	a.deletePort(w, r, port)
+}
+
+func (a *AdminServer) listPorts(w http.ResponseWriter, _ *http.Request) {
+	a.router.mu.RLock()
+	defer a.router.mu.RUnlock()
+
+	ports := make([]PortResponse, 0, len(a.router.portMap))
+	for port, entry := range a.router.portMap {
+		ports = append(ports, PortResponse{
+			Port:       port,
+			CustomerID: entry.customerID,
+			Service:    entry.service,
+		})
+	}
+	writeJSON(w, ports)
+}
+
+func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
+	var req PortCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.Port <= 0 || req.CustomerID == "" || req.Service == "" {
+		http.Error(w, `{"error":"port, customer_id, and service are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if err := a.router.AddPortMapping(req.CustomerID, req.Port, req.Service, req.MaxStreams); err != nil {
+		writeError(w, err.Error(), http.StatusConflict)
+		return
+	}
+
+	a.logger.Info("admin: port mapping added",
+		"port", req.Port,
+		"customer_id", req.CustomerID,
+		"service", req.Service)
+
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, PortResponse{
+		Port:       req.Port,
+		CustomerID: req.CustomerID,
+		Service:    req.Service,
+	})
+}
+
+func (a *AdminServer) deletePort(w http.ResponseWriter, _ *http.Request, port int) {
+	customerID, _, ok := a.router.LookupPort(port)
+	if !ok {
+		http.Error(w, `{"error":"port not found"}`, http.StatusNotFound)
+		return
+	}
+
+	if err := a.router.RemovePortMapping(customerID, port); err != nil {
+		writeError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	a.logger.Info("admin: port mapping removed",
+		"port", port,
+		"customer_id", customerID)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Agents ---
+
+func (a *AdminServer) handleAgents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	agents, err := a.registry.ListConnectedAgents(r.Context())
+	if err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]AgentResponse, len(agents))
+	for i, ag := range agents {
+		resp[i] = AgentResponse{
+			CustomerID:  ag.CustomerID,
+			RemoteAddr:  ag.RemoteAddr,
+			ConnectedAt: ag.ConnectedAt.Format(time.RFC3339),
+			LastSeen:    ag.LastSeen.Format(time.RFC3339),
+			StreamCount: ag.StreamCount,
+		}
+	}
+	writeJSON(w, resp)
+}
+
+func (a *AdminServer) handleAgentByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	customerID := strings.TrimPrefix(r.URL.Path, "/agents/")
+	if customerID == "" {
+		http.Error(w, `{"error":"customer_id required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if err := a.registry.Unregister(r.Context(), customerID); err != nil {
+		writeError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	a.logger.Info("admin: agent disconnected",
+		"customer_id", customerID)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Helpers ---
+
+func writeError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp) //nolint:errcheck // best-effort response
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg}) //nolint:errcheck // best-effort
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v) //nolint:errcheck // best-effort response
 }

--- a/pkg/relay/admin_test.go
+++ b/pkg/relay/admin_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -13,30 +14,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAdminServer_HealthCheck(t *testing.T) {
-	reg := NewMemoryRegistry(slog.Default())
+func testAdminServer(t *testing.T) (addr string, reg *MemoryRegistry, router *PortRouter) {
+	t.Helper()
+	reg = NewMemoryRegistry(slog.Default())
+	router = NewPortRouter(reg, slog.Default())
 
-	// Register one agent
-	conn, agentMux := testConnectionPair("customer-001")
-	defer conn.Close()
-	defer agentMux.Close()
-	require.NoError(t, reg.Register(context.Background(), "customer-001", conn))
-
-	// Find a free port
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	addr := ln.Addr().String()
+	addr = ln.Addr().String()
 	ln.Close()
 
-	admin := NewAdminServer(addr, reg, slog.Default())
+	ctx, cancelFn := context.WithCancel(context.Background())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	admin := NewAdminServer(AdminConfig{
+		Addr:           addr,
+		Registry:       reg,
+		Router:         router,
+		ClientListener: NewClientListener(ClientListenerConfig{Router: router, Logger: slog.Default()}),
+		Logger:         slog.Default(),
+	})
 
 	go func() {
 		admin.Start(ctx) //nolint:errcheck // stopped via ctx cancel
 	}()
 	time.Sleep(100 * time.Millisecond)
+
+	t.Cleanup(cancelFn)
+	return addr, reg, router
+}
+
+func TestAdmin_HealthCheck(t *testing.T) {
+	addr, reg, _ := testAdminServer(t)
+
+	conn, agentMux := testConnectionPair("customer-001")
+	defer conn.Close()
+	defer agentMux.Close()
+	require.NoError(t, reg.Register(context.Background(), "customer-001", conn))
 
 	resp, err := http.Get("http://" + addr + "/healthz")
 	require.NoError(t, err)
@@ -50,27 +63,155 @@ func TestAdminServer_HealthCheck(t *testing.T) {
 	assert.Equal(t, 1, health.Agents)
 }
 
-func TestAdminServer_MetricsEndpoint(t *testing.T) {
-	reg := NewMemoryRegistry(slog.Default())
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := ln.Addr().String()
-	ln.Close()
-
-	admin := NewAdminServer(addr, reg, slog.Default())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		admin.Start(ctx) //nolint:errcheck // stopped via ctx cancel
-	}()
-	time.Sleep(100 * time.Millisecond)
+func TestAdmin_Metrics(t *testing.T) {
+	addr, _, _ := testAdminServer(t)
 
 	resp, err := http.Get("http://" + addr + "/metrics")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestAdmin_Stats(t *testing.T) {
+	addr, _, _ := testAdminServer(t)
+
+	resp, err := http.Get("http://" + addr + "/stats")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var stats StatsResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&stats))
+	assert.Equal(t, "ok", stats.Status)
+	assert.Greater(t, stats.UptimeSeconds, 0.0)
+}
+
+func TestAdmin_ListPorts_Empty(t *testing.T) {
+	addr, _, _ := testAdminServer(t)
+
+	resp, err := http.Get("http://" + addr + "/ports")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var ports []PortResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&ports))
+	assert.Empty(t, ports)
+}
+
+func TestAdmin_CreateAndListPort(t *testing.T) {
+	addr, _, _ := testAdminServer(t)
+
+	// Create
+	body := `{"port":18080,"customer_id":"customer-001","service":"http"}`
+	resp, err := http.Post("http://"+addr+"/ports", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var created PortResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	assert.Equal(t, 18080, created.Port)
+	assert.Equal(t, "customer-001", created.CustomerID)
+
+	// List
+	resp2, err := http.Get("http://" + addr + "/ports")
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	var ports []PortResponse
+	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&ports))
+	assert.Len(t, ports, 1)
+	assert.Equal(t, "http", ports[0].Service)
+}
+
+func TestAdmin_CreatePort_InvalidJSON(t *testing.T) {
+	addr, _, _ := testAdminServer(t)
+
+	resp, err := http.Post("http://"+addr+"/ports", "application/json", bytes.NewBufferString("{bad"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestAdmin_CreatePort_MissingFields(t *testing.T) {
+	addr, _, _ := testAdminServer(t)
+
+	resp, err := http.Post("http://"+addr+"/ports", "application/json", bytes.NewBufferString(`{"port":8080}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestAdmin_DeletePort(t *testing.T) {
+	addr, _, router := testAdminServer(t)
+
+	router.AddPortMapping("customer-001", 18080, "http", 0) //nolint:errcheck // test setup
+
+	req, err := http.NewRequest(http.MethodDelete, "http://"+addr+"/ports/18080", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Verify deleted
+	_, _, ok := router.LookupPort(18080)
+	assert.False(t, ok)
+}
+
+func TestAdmin_DeletePort_NotFound(t *testing.T) {
+	addr, _, _ := testAdminServer(t)
+
+	req, err := http.NewRequest(http.MethodDelete, "http://"+addr+"/ports/99999", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestAdmin_ListAgents(t *testing.T) {
+	addr, reg, _ := testAdminServer(t)
+
+	conn, agentMux := testConnectionPair("customer-001")
+	defer conn.Close()
+	defer agentMux.Close()
+	require.NoError(t, reg.Register(context.Background(), "customer-001", conn))
+
+	resp, err := http.Get("http://" + addr + "/agents")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var agents []AgentResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&agents))
+	assert.Len(t, agents, 1)
+	assert.Equal(t, "customer-001", agents[0].CustomerID)
+}
+
+func TestAdmin_DeleteAgent(t *testing.T) {
+	addr, reg, _ := testAdminServer(t)
+
+	conn, agentMux := testConnectionPair("customer-001")
+	defer agentMux.Close()
+	require.NoError(t, reg.Register(context.Background(), "customer-001", conn))
+
+	req, err := http.NewRequest(http.MethodDelete, "http://"+addr+"/agents/customer-001", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Verify disconnected
+	_, lookupErr := reg.Lookup(context.Background(), "customer-001")
+	assert.ErrorIs(t, lookupErr, ErrAgentNotFound)
 }


### PR DESCRIPTION
## Summary

Phase 6 Step 4: Admin API for runtime port/agent management.

**Endpoints:**
| Method | Path | Description |
|--------|------|-------------|
| GET | /healthz | Health check (existed) |
| GET | /metrics | Prometheus (existed) |
| GET | /ports | List port mappings |
| POST | /ports | Add mapping (no restart) |
| DELETE | /ports/{port} | Remove mapping |
| GET | /agents | List connected agents |
| DELETE | /agents/{id} | Disconnect agent |
| GET | /stats | Relay uptime, counts |

**Transport:** Unix socket (`/var/run/atlax.sock`) + optional TCP (`admin_addr`).

**Usage:**
```bash
# Via unix socket
curl --unix-socket /var/run/atlax.sock http://localhost/ports
curl --unix-socket /var/run/atlax.sock -X POST -d '{"port":18080,"customer_id":"c1","service":"http"}' http://localhost/ports

# Via TCP (if admin_addr configured)
curl http://127.0.0.1:9090/agents
```

Closes #40.

## Test plan

- [x] 11 tests: health, metrics, stats, CRUD ports, CRUD agents, error cases
- [x] All existing tests pass
- [x] Lint clean
- [x] CI passes