### PR TITLE
feat(relay): add StartWithListener for external listener injection

### DIFF
--- a/pkg/relay/client_listener.go
+++ b/pkg/relay/client_listener.go
@@ -56,7 +56,18 @@ func (cl *ClientListener) StartPort(
 	if err != nil {
 		return fmt.Errorf("relay: client listener: port %d: %w", port, err)
 	}
+	return cl.StartPortWithListener(ctx, ln, port)
+}
 
+// StartPortWithListener begins accepting client connections on the given
+// listener for the specified port. Use this instead of StartPort when
+// the listener was created externally (e.g., inherited via fd passing
+// for zero-downtime restart). Blocks until ctx is canceled.
+func (cl *ClientListener) StartPortWithListener(
+	ctx context.Context,
+	ln net.Listener,
+	port int,
+) error {
 	cl.mu.Lock()
 	cl.listeners[port] = ln
 	cl.mu.Unlock()

--- a/pkg/relay/listener.go
+++ b/pkg/relay/listener.go
@@ -50,14 +50,21 @@ func NewAgentListener(cfg AgentListenerConfig) *AgentListener {
 	}
 }
 
-// Start begins accepting agent TLS connections. Blocks until ctx is
-// canceled.
+// Start creates a TLS listener and begins accepting agent connections.
+// Blocks until ctx is canceled.
 func (l *AgentListener) Start(ctx context.Context) error {
 	ln, err := tls.Listen("tcp", l.addr, l.tlsConfig)
 	if err != nil {
 		return fmt.Errorf("relay: agent listener: %w", err)
 	}
+	return l.StartWithListener(ctx, ln)
+}
 
+// StartWithListener begins accepting agent TLS connections on the given
+// listener. Use this instead of Start when the listener was created
+// externally (e.g., inherited via fd passing for zero-downtime restart).
+// Blocks until ctx is canceled.
+func (l *AgentListener) StartWithListener(ctx context.Context, ln net.Listener) error {
 	l.logger.Info("relay: agent listener started", "addr", ln.Addr())
 
 	go func() {


### PR DESCRIPTION
## Summary

- Add `AgentListener.StartWithListener(ctx, ln)` -- accepts a pre-created `net.Listener`
- Add `ClientListener.StartPortWithListener(ctx, ln, port)` -- same for client ports
- Existing `Start` / `StartPort` delegate to the new variants (no behavior change)

These are additive, non-breaking methods that enable enterprise zero-downtime binary swap via fd passing. The new process inherits listening file descriptors from the old process and passes them directly instead of binding fresh.

## Test plan

- [x] `make test` passes (all existing tests unaffected -- they use Start/StartPort which delegate)
- [x] `make lint` passes (0 issues)
- [x] `make build` succeeds

After merge: tag v0.1.2, update enterprise go.mod.