### PR TITLE
fix(systemd): remove WatchdogSec from agent unit (sd_notify never implemented)

### DIFF
--- a/deployments/systemd/atlax-agent.service
+++ b/deployments/systemd/atlax-agent.service
@@ -15,8 +15,6 @@ RestartSec=5s
 
 EnvironmentFile=-/etc/atlax/agent.env
 
-WatchdogSec=30s
-
 # Security hardening
 NoNewPrivileges=yes
 ProtectSystem=strict

--- a/docs/operations/production-setup.md
+++ b/docs/operations/production-setup.md
@@ -651,8 +651,6 @@ RestartSec=5s
 
 EnvironmentFile=-/etc/atlax/agent.env
 
-WatchdogSec=30s
-
 # Security hardening
 NoNewPrivileges=yes
 ProtectSystem=strict
@@ -689,9 +687,9 @@ WantedBy=multi-user.target
 
 Key differences from the relay unit:
 
-- **`WatchdogSec=30s`** -- The agent sends systemd watchdog notifications. If the agent stops responding for 30 seconds, systemd restarts it.
 - **No `CAP_NET_BIND_SERVICE`** -- The agent only makes outbound connections; it never binds privileged ports.
 - **No `RuntimeDirectory`** -- The agent does not use a Unix socket.
+- **No `WatchdogSec`** -- The agent has in-process reconnection supervision (exponential backoff + heartbeat ping) which already handles tunnel failures. A systemd watchdog would require the agent to call `sd_notify(WATCHDOG=1)`, which is not implemented. Restart on crash is still provided by `Restart=always`.
 
 Enable and start:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atlasshare/atlax
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary

The agent systemd unit has set `WatchdogSec=30s` since commit 661201a (Mar 14), but the agent binary never implements `sd_notify(WATCHDOG=1)` -- no `github.com/coreos/go-systemd` import, no `SdNotify` calls anywhere. Systemd has been killing the agent with SIGABRT every 30 seconds in an endless restart loop on every deployment using the hardened unit.

Closes #93

## Impact observed in production

- 47 restarts in hours on the live agent
- 4,990 reconnects over 2 days on the relay (one per ~35s) with 1 actual agent
- Continuous `GOAWAY` -> `EOF` -> `replacing existing agent connection` cycles in relay logs
- Every HTTP request hitting the agent during a kill window returned `HTTP/2 502` from Caddy
- Long-lived connections (Samba, WebSockets) effectively broken

## Fix

Option A from #93: remove `WatchdogSec=30s` from the unit.

The agent already has in-process reconnection supervision (exponential backoff + heartbeat ping), which handles tunnel failures. `Restart=always` still covers process crashes. A systemd watchdog would only add value if the agent deadlocked internally -- and then only with `sd_notify` properly implemented.

Option B (implement real `sd_notify` in the agent) is tracked as a separate enhancement issue.

## Changes

| File | Change |
|------|--------|
| `deployments/systemd/atlax-agent.service` | Remove `WatchdogSec=30s` line |
| `docs/operations/production-setup.md` | Remove the false claim that the agent sends watchdog notifications; document why the agent has no WatchdogSec |

## Verification

Applied the same fix to the live agent (`sudo sed -i '/^WatchdogSec=/d' ...`). Before: 47 restarts, crashing every 30s. After: 0 restarts, uptime steady, no reconnect cycles on the relay.