### PR TITLE
fix: Phase 1 usability bugs -- cert hot-reload, admin API polish, chain cert validation

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -126,7 +126,7 @@ func run() error {
 		watchErr := store.WatchForRotation(ctx,
 			cfg.TLS.CertFile, cfg.TLS.KeyFile,
 			func(cert tls.Certificate) {
-				tlsConfigurator.Reload(cert)
+				tlsConfigurator.Reload(&cert)
 				logger.Info("agent: cert hot-reloaded")
 			})
 		if watchErr != nil && !errors.Is(watchErr, context.Canceled) {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -25,6 +27,7 @@ func main() {
 
 func run() error {
 	configPath := flag.String("config", "agent.yaml", "path to agent configuration file")
+	validate := flag.Bool("validate", false, "parse and validate config file, then exit (0=valid, 1=invalid)")
 	flag.Parse()
 
 	// Load configuration
@@ -32,6 +35,18 @@ func run() error {
 	cfg, err := loader.LoadAgentConfig(*configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
+	}
+
+	// Pre-flight chain cert validation.
+	if err := auth.ValidateChainCertFile(cfg.TLS.CertFile); err != nil {
+		return fmt.Errorf("validate cert: %w", err)
+	}
+
+	// Dry-run mode: config parsed and validated. Exit cleanly.
+	if *validate {
+		fmt.Fprintf(os.Stderr, "config %s is valid (%d services)\n",
+			*configPath, len(cfg.Services))
+		return nil
 	}
 
 	// Initialize logger
@@ -42,7 +57,7 @@ func run() error {
 	defer emitter.Close()
 
 	// Build mTLS configuration
-	store := auth.NewFileStore()
+	store := auth.NewFileStore(auth.WithLogger(logger))
 	tlsConfigurator := auth.NewConfigurator(store, auth.TLSPaths{
 		CertFile:   cfg.TLS.CertFile,
 		KeyFile:    cfg.TLS.KeyFile,
@@ -104,6 +119,19 @@ func run() error {
 	tunnelDone := make(chan error, 1)
 	go func() {
 		tunnelDone <- tunnel.Start(ctx)
+	}()
+
+	// Start the cert rotation watcher.
+	go func() {
+		watchErr := store.WatchForRotation(ctx,
+			cfg.TLS.CertFile, cfg.TLS.KeyFile,
+			func(cert tls.Certificate) {
+				tlsConfigurator.Reload(cert)
+				logger.Info("agent: cert hot-reloaded")
+			})
+		if watchErr != nil && !errors.Is(watchErr, context.Canceled) {
+			logger.Warn("agent: cert watcher exited", "error", watchErr)
+		}
 	}()
 
 	logger.Info("agent started",

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -154,7 +154,7 @@ func run() error {
 		watchErr := store.WatchForRotation(ctx,
 			cfg.TLS.CertFile, cfg.TLS.KeyFile,
 			func(cert tls.Certificate) {
-				tlsConfigurator.Reload(cert)
+				tlsConfigurator.Reload(&cert)
 				logger.Info("relay: cert hot-reloaded")
 			})
 		if watchErr != nil && !errors.Is(watchErr, context.Canceled) {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -27,6 +29,7 @@ func main() {
 
 func run() error {
 	configPath := flag.String("config", "relay.yaml", "path to relay configuration file")
+	validate := flag.Bool("validate", false, "parse and validate config file, then exit (0=valid, 1=invalid)")
 	flag.Parse()
 
 	// Load configuration
@@ -36,6 +39,25 @@ func run() error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	// Build port index from customer config (validates port assignments)
+	portIndex, err := config.BuildPortIndex(cfg.Customers)
+	if err != nil {
+		return fmt.Errorf("build port index: %w", err)
+	}
+
+	// Pre-flight chain cert validation. Catches the common footgun of
+	// pointing cert_file at a bare leaf instead of a chain cert.
+	if err := auth.ValidateChainCertFile(cfg.TLS.CertFile); err != nil {
+		return fmt.Errorf("validate cert: %w", err)
+	}
+
+	// Dry-run mode: config parsed and validated. Exit cleanly.
+	if *validate {
+		fmt.Fprintf(os.Stderr, "config %s is valid (%d customers, %d ports)\n",
+			*configPath, len(cfg.Customers), len(portIndex.Entries))
+		return nil
+	}
+
 	// Initialize logger
 	logger := initLogger(cfg.Logging)
 
@@ -43,14 +65,8 @@ func run() error {
 	emitter := audit.NewSlogEmitter(logger, audit.DefaultBufferSize)
 	defer emitter.Close()
 
-	// Build port index from customer config
-	portIndex, err := config.BuildPortIndex(cfg.Customers)
-	if err != nil {
-		return fmt.Errorf("build port index: %w", err)
-	}
-
 	// Build server-side mTLS configuration
-	store := auth.NewFileStore()
+	store := auth.NewFileStore(auth.WithLogger(logger))
 	tlsConfigurator := auth.NewConfigurator(store, auth.TLSPaths{
 		CertFile:     cfg.TLS.CertFile,
 		KeyFile:      cfg.TLS.KeyFile,
@@ -129,6 +145,21 @@ func run() error {
 	serverDone := make(chan error, 1)
 	go func() {
 		serverDone <- server.Start(ctx)
+	}()
+
+	// Start the cert rotation watcher. Polls the cert file for content
+	// changes and calls tlsConfigurator.Reload() so new handshakes use
+	// the updated cert without a process restart.
+	go func() {
+		watchErr := store.WatchForRotation(ctx,
+			cfg.TLS.CertFile, cfg.TLS.KeyFile,
+			func(cert tls.Certificate) {
+				tlsConfigurator.Reload(cert)
+				logger.Info("relay: cert hot-reloaded")
+			})
+		if watchErr != nil && !errors.Is(watchErr, context.Canceled) {
+			logger.Warn("relay: cert watcher exited", "error", watchErr)
+		}
 	}()
 
 	logger.Info("relay started",

--- a/configs/relay.example.yaml
+++ b/configs/relay.example.yaml
@@ -7,8 +7,11 @@ server:
   # Address for agent TLS connections (mTLS)
   listen_addr: ":8443"
 
-  # Address for the admin/metrics API
-  admin_addr: ":9090"
+  # Address for the admin/metrics API.
+  # NOTE: Port 9090 is also Prometheus's default. If you run Prometheus
+  # on the same host, change one of them (e.g., Prometheus to :9091)
+  # to avoid a bind conflict.
+  admin_addr: "127.0.0.1:9090"
 
   # Unix socket for admin API (optional, empty = TCP only).
   # Requires RuntimeDirectory=atlax in the systemd unit.

--- a/docs/api/control-plane.md
+++ b/docs/api/control-plane.md
@@ -51,6 +51,24 @@ Liveness probe. Returns agent and stream counts.
 
 ---
 
+### GET /readyz
+
+Readiness probe. Returns 200 when the registry is reachable and the admin server is serving requests. Suitable for ALB target group health checks. Distinct from `/healthz` which additionally reports agent/stream counts.
+
+**Response (ready):** `200 OK`
+
+```json
+{"status": "ready"}
+```
+
+**Response (not ready):** `503 Service Unavailable`
+
+```json
+{"status": "not ready"}
+```
+
+---
+
 ### GET /metrics
 
 Prometheus exposition format. Serves all `atlax_*` metrics via `promhttp.Handler()`.
@@ -88,15 +106,31 @@ List all active port-to-customer mappings.
   {
     "port": 18445,
     "customer_id": "customer-001",
-    "service": "smb"
+    "service": "smb",
+    "listen_addr": "127.0.0.1",
+    "max_streams": 0
   },
   {
     "port": 18080,
     "customer_id": "customer-001",
-    "service": "http"
+    "service": "http",
+    "listen_addr": "0.0.0.0",
+    "max_streams": 50
   }
 ]
 ```
+
+---
+
+### GET /ports/{port}
+
+Inspect a single port mapping.
+
+**Success:** `200 OK` with the same `PortResponse` object as `GET /ports`.
+
+**Errors:**
+- `400 Bad Request` -- invalid port number
+- `404 Not Found` -- no mapping for this port
 
 ---
 
@@ -168,6 +202,18 @@ List all connected agents.
   }
 ]
 ```
+
+---
+
+### GET /agents/{customerID}
+
+Inspect a single connected agent.
+
+**Success:** `200 OK` with the same `AgentResponse` object as `GET /agents`.
+
+**Errors:**
+- `400 Bad Request` -- empty customer ID
+- `404 Not Found` -- agent not connected
 
 ---
 

--- a/docs/operations/certificate-ops.md
+++ b/docs/operations/certificate-ops.md
@@ -239,53 +239,43 @@ cfssl gencert -ca ca.pem -ca-key ca-key.pem \
 5. Deliver the signed certificate and CA bundle to the customer agent.
 6. Record the certificate serial number, customer ID, and expiry date in the certificate inventory.
 
-### Automated Renewal
+### Certificate Rotation (Community Edition)
 
-The agent checks certificate expiry daily and initiates renewal when less than 30 days remain:
+The community edition supports file-based hot-reload: both the relay and agent poll their cert files (default: every 24 hours) and automatically reload when the content changes (SHA-256 fingerprint comparison). No process restart is needed.
 
-1. Agent generates a new key pair (or reuses the existing key, based on configuration).
-2. Agent creates a CSR with the same `CN=customer-{uuid}`.
-3. Agent submits the CSR to the control plane API endpoint (`/api/v1/certs/renew`), authenticated with the current (still valid) mTLS certificate.
-4. Control plane validates the request and signs the CSR with the Customer Intermediate CA.
-5. Agent receives the new certificate, validates the chain, and hot-reloads.
-6. Old certificate remains valid until its original expiry (overlap period).
+**Operator workflow:**
+
+1. Generate a new cert+key pair using the same CA that signed the original.
+2. Create a new chain file: `cat new-leaf.crt intermediate-ca.crt > new-chain.crt`.
+3. Replace the chain file and key on disk at the paths specified in the config (`cert_file`, `key_file`).
+4. Wait up to 24 hours for the next poll cycle, or restart the service for immediate pickup.
+
+**Automated renewal via CA API** (step-ca ACME, Vault PKI `/issue` endpoint) is supported by the enterprise edition. The community edition does not have an automated renewal agent -- cert rotation is operator-initiated.
+
+To generate a new agent cert for an existing customer without regenerating the full CA hierarchy, use the `ats certs issue` command from `atlax-tools`:
+
+```bash
+ats certs issue
+# Prompts for cert dir, customer ID, validity. Signs against existing Customer CA.
+```
 
 ---
 
 ## Revocation
 
-### Certificate Revocation List (CRL)
+The community edition does not implement CRL fetching or OCSP checking. Revocation is enforced by short-lived certificates (90-day default) and operator-initiated disconnection via the admin API.
 
-The relay periodically fetches an updated CRL from the CA and rejects connections from revoked certificates.
+**Practical revocation procedure (community):**
 
-```bash
-# Generate CRL with OpenSSL (development)
-openssl ca -config ca.conf -gencrl -out crl.pem
-
-# With step-ca
-step ca revoke <serial-number>
-
-# With Vault
-vault write pki_customer/revoke serial_number=<serial>
-```
-
-### OCSP (Online Certificate Status Protocol)
-
-For production deployments with step-ca or Vault, enable OCSP responder for real-time certificate status checks.
-
-### Revocation Procedure
-
-1. Identify the certificate to revoke (by serial number or customer ID).
-2. Revoke the certificate in the CA.
-3. Distribute the updated CRL to the relay (or ensure OCSP is checked).
-4. Verify the revoked certificate is rejected:
+1. Identify the compromised agent by customer ID.
+2. Force-disconnect via the admin API:
    ```bash
-   # Attempt connection with revoked cert (should fail)
-   openssl s_client -connect relay.example.com:8443 \
-     -cert revoked-agent.crt -key revoked-agent.key \
-     -CAfile relay-ca.crt
+   curl -X DELETE http://127.0.0.1:9090/agents/{customerID}
    ```
-5. Issue a new certificate to the customer if the revocation was due to compromise (with a new key pair).
+3. Do not re-issue a cert for that customer until the compromise is resolved.
+4. The short 90-day validity limits the exposure window.
+
+For CRL/OCSP enforcement, use the enterprise edition with step-ca or Vault PKI.
 
 ---
 

--- a/pkg/auth/certs_impl.go
+++ b/pkg/auth/certs_impl.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"os"
@@ -56,6 +57,47 @@ func (s *FileStore) LoadCertificate(certPath, keyPath string) (tls.Certificate, 
 		return tls.Certificate{}, fmt.Errorf("auth: load certificate: %w", err)
 	}
 	return cert, nil
+}
+
+// ValidateChainCertFile reads a PEM file and verifies it contains at
+// least two certificates (a leaf cert followed by an intermediate CA).
+// This is a pre-flight check to catch the common mistake of pointing
+// cert_file at a bare leaf cert -- the TLS handshake then fails with
+// a cryptic "unknown certificate authority" error on the peer side.
+//
+// Returns nil on success. Returns an error that explains what's wrong
+// and how to fix it if the file contains a single certificate.
+func ValidateChainCertFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("auth: validate chain: read %s: %w", path, err)
+	}
+
+	count := 0
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			count++
+		}
+	}
+
+	if count == 0 {
+		return fmt.Errorf("auth: validate chain: no certificates found in %s", path)
+	}
+	if count == 1 {
+		return fmt.Errorf(
+			"auth: validate chain: %s contains a single certificate (bare leaf, no intermediate CA). "+
+				"atlax requires a chain cert: concatenate the leaf and intermediate CA into a single file "+
+				"(e.g. `cat leaf.crt intermediate.crt > chain.crt`) and point cert_file at the chain",
+			path,
+		)
+	}
+	return nil
 }
 
 // LoadCertificateAuthority reads one or more PEM-encoded CA certificates

--- a/pkg/auth/certs_impl.go
+++ b/pkg/auth/certs_impl.go
@@ -103,13 +103,13 @@ func ValidateChainCertFile(path string) error {
 // LoadCertificateAuthority reads one or more PEM-encoded CA certificates
 // and returns an x509.CertPool.
 func (s *FileStore) LoadCertificateAuthority(path string) (*x509.CertPool, error) {
-	pem, err := os.ReadFile(path)
+	pemData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("auth: load ca: %w", err)
 	}
 
 	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(pem) {
+	if !pool.AppendCertsFromPEM(pemData) {
 		return nil, fmt.Errorf("auth: load ca: no valid certificates in %s", path)
 	}
 	return pool, nil

--- a/pkg/auth/certs_impl_test.go
+++ b/pkg/auth/certs_impl_test.go
@@ -179,6 +179,37 @@ func testCertsDir() string {
 	return filepath.Join("..", "..", "certs")
 }
 
+func TestValidateChainCertFile_Chain(t *testing.T) {
+	// relay-chain.crt is a proper chain (leaf + intermediate CA).
+	err := ValidateChainCertFile(filepath.Join(testCertsDir(), "relay-chain.crt"))
+	require.NoError(t, err)
+}
+
+func TestValidateChainCertFile_BareCert(t *testing.T) {
+	// relay.crt is a bare leaf certificate.
+	err := ValidateChainCertFile(filepath.Join(testCertsDir(), "relay.crt"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single certificate")
+	assert.Contains(t, err.Error(), "bare leaf")
+	assert.Contains(t, err.Error(), "intermediate")
+}
+
+func TestValidateChainCertFile_Missing(t *testing.T) {
+	err := ValidateChainCertFile("/nonexistent/chain.pem")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read")
+}
+
+func TestValidateChainCertFile_Empty(t *testing.T) {
+	tmp := t.TempDir()
+	empty := filepath.Join(tmp, "empty.pem")
+	require.NoError(t, os.WriteFile(empty, []byte("not a cert"), 0o600))
+
+	err := ValidateChainCertFile(empty)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no certificates found")
+}
+
 func copyFile(t *testing.T, src, dst string) {
 	t.Helper()
 	data, err := os.ReadFile(src)

--- a/pkg/auth/mtls.go
+++ b/pkg/auth/mtls.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/tls"
 	"fmt"
+	"sync/atomic"
 	"time"
 )
 
@@ -66,10 +67,18 @@ type TLSPaths struct {
 	ServerName   string
 }
 
-// Configurator builds TLS configs from file-based certificates.
+// Configurator builds TLS configs from file-based certificates and
+// supports hot-reload of the leaf certificate via Reload().
 type Configurator struct {
 	store CertificateStore
 	paths TLSPaths
+
+	// currentCert is the live certificate pointer served by the
+	// GetCertificate / GetClientCertificate callbacks in the tls.Config
+	// returned from ServerTLSConfig / ClientTLSConfig. Swapping this
+	// atomically reloads the certificate for the next handshake without
+	// rebuilding the tls.Config.
+	currentCert atomic.Pointer[tls.Certificate]
 }
 
 // Compile-time interface check.
@@ -82,7 +91,19 @@ func NewConfigurator(store CertificateStore, paths TLSPaths) *Configurator {
 	return &Configurator{store: store, paths: paths}
 }
 
-// ServerTLSConfig returns a tls.Config for the relay listener with mTLS.
+// Reload swaps the certificate served by the tls.Config callbacks.
+// Safe to call from any goroutine, including concurrent with active
+// TLS handshakes. The new certificate takes effect on the next
+// handshake; existing connections are not torn down.
+func (c *Configurator) Reload(cert tls.Certificate) {
+	c.currentCert.Store(&cert)
+}
+
+// ServerTLSConfig returns a tls.Config for the relay listener with
+// mTLS. The returned config uses a GetCertificate callback that reads
+// the current certificate from an atomic pointer, so calling Reload()
+// later swaps the certificate for new handshakes without rebuilding
+// the config or restarting the listener.
 func (c *Configurator) ServerTLSConfig(opts ...TLSOption) (*tls.Config, error) {
 	o := tlsOptions{MinVersion: tls.VersionTLS13}
 	for _, fn := range opts {
@@ -93,6 +114,7 @@ func (c *Configurator) ServerTLSConfig(opts ...TLSOption) (*tls.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("auth: server tls: %w", err)
 	}
+	c.currentCert.Store(&cert)
 
 	clientCAs, err := c.store.LoadCertificateAuthority(c.paths.ClientCAFile)
 	if err != nil {
@@ -100,14 +122,18 @@ func (c *Configurator) ServerTLSConfig(opts ...TLSOption) (*tls.Config, error) {
 	}
 
 	return &tls.Config{ //nolint:gosec // default is TLS 1.3; WithMinVersion is for testing only
-		MinVersion:   o.MinVersion,
-		Certificates: []tls.Certificate{cert},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    clientCAs,
+		MinVersion: o.MinVersion,
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return c.currentCert.Load(), nil
+		},
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  clientCAs,
 	}, nil
 }
 
-// ClientTLSConfig returns a tls.Config for the agent dialer with mTLS.
+// ClientTLSConfig returns a tls.Config for the agent dialer with
+// mTLS. The returned config uses a GetClientCertificate callback so
+// calling Reload() swaps the certificate for the next handshake.
 func (c *Configurator) ClientTLSConfig(opts ...TLSOption) (*tls.Config, error) {
 	o := tlsOptions{MinVersion: tls.VersionTLS13}
 	for _, fn := range opts {
@@ -118,6 +144,7 @@ func (c *Configurator) ClientTLSConfig(opts ...TLSOption) (*tls.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("auth: client tls: %w", err)
 	}
+	c.currentCert.Store(&cert)
 
 	rootCAs, err := c.store.LoadCertificateAuthority(c.paths.CAFile)
 	if err != nil {
@@ -125,10 +152,12 @@ func (c *Configurator) ClientTLSConfig(opts ...TLSOption) (*tls.Config, error) {
 	}
 
 	cfg := &tls.Config{ //nolint:gosec // default is TLS 1.3; WithMinVersion is for testing only
-		MinVersion:   o.MinVersion,
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      rootCAs,
-		ServerName:   c.paths.ServerName,
+		MinVersion: o.MinVersion,
+		GetClientCertificate: func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return c.currentCert.Load(), nil
+		},
+		RootCAs:    rootCAs,
+		ServerName: c.paths.ServerName,
 	}
 
 	if o.SessionCache != nil {

--- a/pkg/auth/mtls.go
+++ b/pkg/auth/mtls.go
@@ -95,8 +95,8 @@ func NewConfigurator(store CertificateStore, paths TLSPaths) *Configurator {
 // Safe to call from any goroutine, including concurrent with active
 // TLS handshakes. The new certificate takes effect on the next
 // handshake; existing connections are not torn down.
-func (c *Configurator) Reload(cert tls.Certificate) {
-	c.currentCert.Store(&cert)
+func (c *Configurator) Reload(cert *tls.Certificate) {
+	c.currentCert.Store(cert)
 }
 
 // ServerTLSConfig returns a tls.Config for the relay listener with

--- a/pkg/auth/mtls_test.go
+++ b/pkg/auth/mtls_test.go
@@ -117,7 +117,7 @@ func TestConfigurator_Reload_SwapsCertificate(t *testing.T) {
 		filepath.Join(testCertsDir(), "agent.key"),
 	)
 	require.NoError(t, err)
-	cfg.Reload(agentCert)
+	cfg.Reload(&agentCert)
 
 	second, err := tlsCfg.GetCertificate(nil)
 	require.NoError(t, err)

--- a/pkg/auth/mtls_test.go
+++ b/pkg/auth/mtls_test.go
@@ -29,7 +29,13 @@ func TestConfigurator_ServerTLSConfig_HasRelayCert(t *testing.T) {
 	cfg := relayConfigurator(t)
 	tlsCfg, err := cfg.ServerTLSConfig()
 	require.NoError(t, err)
-	assert.Len(t, tlsCfg.Certificates, 1)
+	// Cert is served via GetCertificate callback (hot-reload path),
+	// not the static Certificates slice.
+	assert.NotNil(t, tlsCfg.GetCertificate)
+	cert, err := tlsCfg.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	assert.NotEmpty(t, cert.Certificate)
 }
 
 func TestConfigurator_ServerTLSConfig_HasClientCAs(t *testing.T) {
@@ -85,7 +91,40 @@ func TestConfigurator_ClientTLSConfig_HasAgentCert(t *testing.T) {
 	cfg := agentConfigurator(t)
 	tlsCfg, err := cfg.ClientTLSConfig()
 	require.NoError(t, err)
-	assert.Len(t, tlsCfg.Certificates, 1)
+	// Cert is served via GetClientCertificate callback (hot-reload path),
+	// not the static Certificates slice.
+	assert.NotNil(t, tlsCfg.GetClientCertificate)
+	cert, err := tlsCfg.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	assert.NotEmpty(t, cert.Certificate)
+}
+
+func TestConfigurator_Reload_SwapsCertificate(t *testing.T) {
+	cfg := relayConfigurator(t)
+	tlsCfg, err := cfg.ServerTLSConfig()
+	require.NoError(t, err)
+
+	first, err := tlsCfg.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	firstFP := CertFingerprint(first.Certificate[0])
+
+	// Load a different cert (agent.crt is a different leaf) and reload.
+	store := NewFileStore()
+	agentCert, err := store.LoadCertificate(
+		filepath.Join(testCertsDir(), "agent.crt"),
+		filepath.Join(testCertsDir(), "agent.key"),
+	)
+	require.NoError(t, err)
+	cfg.Reload(agentCert)
+
+	second, err := tlsCfg.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	secondFP := CertFingerprint(second.Certificate[0])
+
+	assert.NotEqual(t, firstFP, secondFP, "reloaded cert should differ from initial cert")
 }
 
 func TestConfigurator_ClientTLSConfig_HasRootCAs(t *testing.T) {

--- a/pkg/relay/admin.go
+++ b/pkg/relay/admin.go
@@ -65,6 +65,8 @@ type PortResponse struct {
 	Port       int    `json:"port"`
 	CustomerID string `json:"customer_id"`
 	Service    string `json:"service"`
+	ListenAddr string `json:"listen_addr"`
+	MaxStreams int    `json:"max_streams"`
 }
 
 // AgentResponse represents a connected agent in API responses.
@@ -98,8 +100,9 @@ func NewAdminServer(cfg AdminConfig) *AdminServer {
 
 	mux := http.NewServeMux()
 
-	// Existing endpoints
+	// Liveness + readiness + metrics
 	mux.HandleFunc("/healthz", a.handleHealth)
+	mux.HandleFunc("/readyz", a.handleReady)
 	mux.Handle("/metrics", promhttp.Handler())
 
 	// CRUD endpoints
@@ -198,6 +201,20 @@ func (a *AdminServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// --- Readiness ---
+
+// handleReady returns 200 when the registry is reachable and the admin
+// server is serving requests (which it must be, to handle this call).
+// Distinct from /healthz which counts active agents: /readyz is a
+// liveness+registry probe suitable for ALB target group health checks.
+func (a *AdminServer) handleReady(w http.ResponseWriter, r *http.Request) {
+	if _, err := a.registry.ListConnectedAgents(r.Context()); err != nil {
+		http.Error(w, `{"status":"not ready"}`, http.StatusServiceUnavailable)
+		return
+	}
+	writeJSON(w, map[string]string{"status": "ready"})
+}
+
 // --- Stats ---
 
 func (a *AdminServer) handleStats(w http.ResponseWriter, r *http.Request) {
@@ -241,11 +258,6 @@ func (a *AdminServer) handlePorts(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *AdminServer) handlePortByID(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodDelete {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
-		return
-	}
-
 	portStr := strings.TrimPrefix(r.URL.Path, "/ports/")
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
@@ -253,22 +265,42 @@ func (a *AdminServer) handlePortByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.deletePort(w, r, port)
+	switch r.Method {
+	case http.MethodGet:
+		a.getPort(w, port)
+	case http.MethodDelete:
+		a.deletePort(w, r, port)
+	default:
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
 }
 
 func (a *AdminServer) listPorts(w http.ResponseWriter, _ *http.Request) {
-	a.router.mu.RLock()
-	defer a.router.mu.RUnlock()
-
-	ports := make([]PortResponse, 0, len(a.router.portMap))
-	for port, entry := range a.router.portMap {
-		ports = append(ports, PortResponse{
-			Port:       port,
-			CustomerID: entry.customerID,
-			Service:    entry.service,
-		})
+	infos := a.router.ListPorts()
+	ports := make([]PortResponse, 0, len(infos))
+	for _, info := range infos {
+		ports = append(ports, portInfoToResponse(info))
 	}
 	writeJSON(w, ports)
+}
+
+func (a *AdminServer) getPort(w http.ResponseWriter, port int) {
+	info, ok := a.router.GetPort(port)
+	if !ok {
+		http.Error(w, `{"error":"port not found"}`, http.StatusNotFound)
+		return
+	}
+	writeJSON(w, portInfoToResponse(info))
+}
+
+func portInfoToResponse(info PortInfo) PortResponse {
+	return PortResponse{
+		Port:       info.Port,
+		CustomerID: info.CustomerID,
+		Service:    info.Service,
+		ListenAddr: info.ListenAddr,
+		MaxStreams: info.MaxStreams,
+	}
 }
 
 func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
@@ -283,16 +315,17 @@ func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := a.router.AddPortMapping(req.CustomerID, req.Port, req.Service, req.MaxStreams); err != nil {
-		writeError(w, err.Error(), http.StatusConflict)
-		return
-	}
-
-	// Start a TCP listener for the new port.
+	// Default listen address.
 	listenAddr := req.ListenAddr
 	if listenAddr == "" {
 		listenAddr = "0.0.0.0"
 	}
+
+	if err := a.router.AddPortMapping(req.CustomerID, req.Port, req.Service, listenAddr, req.MaxStreams); err != nil {
+		writeError(w, err.Error(), http.StatusConflict)
+		return
+	}
+
 	addr := fmt.Sprintf("%s:%d", listenAddr, req.Port)
 
 	listenerCtx := a.ctx
@@ -316,7 +349,10 @@ func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
 		// Listener started successfully (blocking in accept loop).
 	}
 
-	a.logger.Info("admin: port mapping added",
+	// Runtime-only: remind the operator that this change is not persisted
+	// to the config file and will be lost on restart. See
+	// docs/api/control-plane.md#persistence.
+	a.logger.Warn("admin: port mapping added at runtime is not persisted; add to relay.yaml to survive restart",
 		"port", req.Port,
 		"customer_id", req.CustomerID,
 		"service", req.Service,
@@ -327,6 +363,8 @@ func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
 		Port:       req.Port,
 		CustomerID: req.CustomerID,
 		Service:    req.Service,
+		ListenAddr: listenAddr,
+		MaxStreams: req.MaxStreams,
 	})
 }
 
@@ -342,14 +380,18 @@ func (a *AdminServer) deletePort(w http.ResponseWriter, _ *http.Request, port in
 		return
 	}
 
-	// Stop the TCP listener for this port. Log warning if it was not
-	// admin-started (e.g., started from config at boot).
+	// Stop the TCP listener for this port. Both config-started and
+	// admin-started listeners are registered in ClientListener.listeners,
+	// so StopPort handles both. If it errors here the listener simply
+	// was not known (unusual; log but do not fail the request).
 	if err := a.clientListener.StopPort(port); err != nil {
-		a.logger.Warn("admin: stop listener (may be config-started)",
+		a.logger.Warn("admin: stop listener failed",
 			"port", port, "error", err)
 	}
 
-	a.logger.Info("admin: port mapping removed",
+	// Runtime-only: if the port is also defined in relay.yaml, the
+	// config will re-add it on next restart. Warn the operator.
+	a.logger.Warn("admin: port mapping removed at runtime; also remove from relay.yaml to prevent reappearance on restart",
 		"port", port,
 		"customer_id", customerID)
 
@@ -384,17 +426,44 @@ func (a *AdminServer) handleAgents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *AdminServer) handleAgentByID(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodDelete {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
-		return
-	}
-
 	customerID := strings.TrimPrefix(r.URL.Path, "/agents/")
 	if customerID == "" {
 		http.Error(w, `{"error":"customer_id required"}`, http.StatusBadRequest)
 		return
 	}
 
+	switch r.Method {
+	case http.MethodGet:
+		a.getAgent(w, r, customerID)
+	case http.MethodDelete:
+		a.deleteAgent(w, r, customerID)
+	default:
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *AdminServer) getAgent(w http.ResponseWriter, r *http.Request, customerID string) {
+	agents, err := a.registry.ListConnectedAgents(r.Context())
+	if err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
+	for _, ag := range agents {
+		if ag.CustomerID == customerID {
+			writeJSON(w, AgentResponse{
+				CustomerID:  ag.CustomerID,
+				RemoteAddr:  ag.RemoteAddr,
+				ConnectedAt: ag.ConnectedAt.Format(time.RFC3339),
+				LastSeen:    ag.LastSeen.Format(time.RFC3339),
+				StreamCount: ag.StreamCount,
+			})
+			return
+		}
+	}
+	http.Error(w, `{"error":"agent not found"}`, http.StatusNotFound)
+}
+
+func (a *AdminServer) deleteAgent(w http.ResponseWriter, r *http.Request, customerID string) {
 	if err := a.registry.Unregister(r.Context(), customerID); err != nil {
 		writeError(w, err.Error(), http.StatusNotFound)
 		return

--- a/pkg/relay/admin_test.go
+++ b/pkg/relay/admin_test.go
@@ -152,7 +152,7 @@ func TestAdmin_CreatePort_MissingFields(t *testing.T) {
 func TestAdmin_DeletePort(t *testing.T) {
 	addr, _, router, _ := testAdminServer(t)
 
-	router.AddPortMapping("customer-001", 18080, "http", 0) //nolint:errcheck // test setup
+	router.AddPortMapping("customer-001", 18080, "http", "", 0) //nolint:errcheck // test setup
 
 	req, err := http.NewRequest(http.MethodDelete, "http://"+addr+"/ports/18080", http.NoBody)
 	require.NoError(t, err)
@@ -327,7 +327,10 @@ func TestAdmin_Agents_MethodNotAllowed(t *testing.T) {
 func TestAdmin_AgentByID_MethodNotAllowed(t *testing.T) {
 	addr, _, _, _ := testAdminServer(t)
 
-	resp, err := http.Get("http://" + addr + "/agents/customer-001")
+	// GET and DELETE are now both valid. PUT is not.
+	req, err := http.NewRequest(http.MethodPut, "http://"+addr+"/agents/customer-001", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
@@ -355,10 +358,97 @@ func TestAdmin_PortByID_InvalidPort(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestAdmin_ReadyCheck(t *testing.T) {
+	addr, _, _, _ := testAdminServer(t)
+
+	resp, err := http.Get("http://" + addr + "/readyz")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "ready", body["status"])
+}
+
+func TestAdmin_GetPort_Found(t *testing.T) {
+	addr, _, router, _ := testAdminServer(t)
+	require.NoError(t, router.AddPortMapping("customer-001", 19200, "http", "127.0.0.1", 50))
+
+	resp, err := http.Get("http://" + addr + "/ports/19200")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var got PortResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, 19200, got.Port)
+	assert.Equal(t, "customer-001", got.CustomerID)
+	assert.Equal(t, "http", got.Service)
+	assert.Equal(t, "127.0.0.1", got.ListenAddr)
+	assert.Equal(t, 50, got.MaxStreams)
+}
+
+func TestAdmin_GetPort_NotFound(t *testing.T) {
+	addr, _, _, _ := testAdminServer(t)
+
+	resp, err := http.Get("http://" + addr + "/ports/65000")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestAdmin_ListPorts_IncludesListenAddrAndMaxStreams(t *testing.T) {
+	addr, _, router, _ := testAdminServer(t)
+	require.NoError(t, router.AddPortMapping("customer-001", 19201, "http", "127.0.0.1", 42))
+
+	resp, err := http.Get("http://" + addr + "/ports")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var ports []PortResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&ports))
+	require.Len(t, ports, 1)
+	assert.Equal(t, "127.0.0.1", ports[0].ListenAddr)
+	assert.Equal(t, 42, ports[0].MaxStreams)
+}
+
+func TestAdmin_GetAgent_Found(t *testing.T) {
+	addr, reg, _, _ := testAdminServer(t)
+
+	conn, agentMux := testConnectionPair("customer-001")
+	defer conn.Close()
+	defer agentMux.Close()
+	require.NoError(t, reg.Register(context.Background(), "customer-001", conn))
+
+	resp, err := http.Get("http://" + addr + "/agents/customer-001")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var got AgentResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "customer-001", got.CustomerID)
+}
+
+func TestAdmin_GetAgent_NotFound(t *testing.T) {
+	addr, _, _, _ := testAdminServer(t)
+
+	resp, err := http.Get("http://" + addr + "/agents/customer-unknown")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 func TestAdmin_PortByID_MethodNotAllowed(t *testing.T) {
 	addr, _, _, _ := testAdminServer(t)
 
-	resp, err := http.Get("http://" + addr + "/ports/12345")
+	// GET and DELETE are now both valid. PUT is not.
+	req, err := http.NewRequest(http.MethodPut, "http://"+addr+"/ports/12345", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)

--- a/pkg/relay/client_listener_test.go
+++ b/pkg/relay/client_listener_test.go
@@ -119,7 +119,7 @@ func TestClientListener_HandleClient_RateLimited(t *testing.T) {
 	cl := NewClientListener(ClientListenerConfig{Router: router, Logger: slog.Default()})
 
 	// Add a port mapping so lookup succeeds.
-	require.NoError(t, router.AddPortMapping("customer-001", 19094, "http", 0))
+	require.NoError(t, router.AddPortMapping("customer-001", 19094, "http", "", 0))
 
 	// Set a very restrictive rate limit: 1 req/s, burst 1.
 	cl.SetRateLimiter("customer-001", 1, 1)
@@ -146,7 +146,7 @@ func TestClientListener_HandleClient_RouteFails(t *testing.T) {
 	cl := NewClientListener(ClientListenerConfig{Router: router, Logger: slog.Default()})
 
 	// Port mapped but no agent registered -- Route will fail.
-	require.NoError(t, router.AddPortMapping("customer-001", 19095, "http", 0))
+	require.NoError(t, router.AddPortMapping("customer-001", 19095, "http", "", 0))
 
 	server, client := net.Pipe()
 	defer server.Close()

--- a/pkg/relay/isolation_test.go
+++ b/pkg/relay/isolation_test.go
@@ -21,9 +21,9 @@ func TestCrossTenantIsolation(t *testing.T) {
 	router := NewPortRouter(reg, slog.Default())
 
 	// Customer A: port 19001, service "echo-a"
-	router.AddPortMapping("customer-a", 19001, "echo-a", 0) //nolint:errcheck // test setup
+	router.AddPortMapping("customer-a", 19001, "echo-a", "", 0) //nolint:errcheck // test setup
 	// Customer B: port 19002, service "echo-b"
-	router.AddPortMapping("customer-b", 19002, "echo-b", 0) //nolint:errcheck // test setup
+	router.AddPortMapping("customer-b", 19002, "echo-b", "", 0) //nolint:errcheck // test setup
 
 	// Create mux pairs for both customers
 	relayConnA, agentConnA := net.Pipe()
@@ -134,7 +134,7 @@ func TestCrossTenantIsolation_PortACannotReachAgentB(t *testing.T) {
 	router := NewPortRouter(reg, slog.Default())
 
 	// Only customer-a mapped to port 19001
-	router.AddPortMapping("customer-a", 19001, "echo", 0) //nolint:errcheck // test setup
+	router.AddPortMapping("customer-a", 19001, "echo", "", 0) //nolint:errcheck // test setup
 
 	// Register customer-b (but NOT customer-a)
 	relayConn, agentConn := net.Pipe()

--- a/pkg/relay/router.go
+++ b/pkg/relay/router.go
@@ -12,9 +12,11 @@ type TrafficRouter interface {
 	// customer ID. The port identifies which service to route to.
 	Route(ctx context.Context, customerID string, clientConn net.Conn, port int) error
 
-	// AddPortMapping assigns a relay-side port to a specific service for the
-	// given customer. maxStreams of 0 means unlimited.
-	AddPortMapping(customerID string, port int, service string, maxStreams int) error
+	// AddPortMapping assigns a relay-side port to a specific service for
+	// the given customer. listenAddr is recorded for introspection (the
+	// admin API reports it back) but does not affect routing. maxStreams
+	// of 0 means unlimited.
+	AddPortMapping(customerID string, port int, service, listenAddr string, maxStreams int) error
 
 	// RemovePortMapping releases a previously assigned port mapping.
 	RemovePortMapping(customerID string, port int) error

--- a/pkg/relay/router_impl.go
+++ b/pkg/relay/router_impl.go
@@ -29,6 +29,7 @@ type portEntry struct {
 	customerID string
 	service    string
 	maxStreams int
+	listenAddr string
 }
 
 // Compile-time interface check.
@@ -47,15 +48,63 @@ func NewPortRouter(registry AgentRegistry, logger *slog.Logger) *PortRouter {
 }
 
 // AddPortMapping assigns a relay-side port to a customer's service.
-func (r *PortRouter) AddPortMapping(customerID string, port int, service string, maxStreams int) error {
+// The listenAddr is recorded for introspection via the admin API but
+// does not affect routing.
+func (r *PortRouter) AddPortMapping(customerID string, port int, service, listenAddr string, maxStreams int) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.portMap[port] = portEntry{
 		customerID: customerID,
 		service:    service,
 		maxStreams: maxStreams,
+		listenAddr: listenAddr,
 	}
 	return nil
+}
+
+// PortInfo is a read-only view of a port mapping used by the admin API
+// and other callers that need to introspect the router state.
+type PortInfo struct {
+	Port       int
+	CustomerID string
+	Service    string
+	MaxStreams int
+	ListenAddr string
+}
+
+// GetPort returns the full mapping for a single port, or (_, false) if
+// the port is not registered.
+func (r *PortRouter) GetPort(port int) (PortInfo, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.portMap[port]
+	if !ok {
+		return PortInfo{}, false
+	}
+	return PortInfo{
+		Port:       port,
+		CustomerID: entry.customerID,
+		Service:    entry.service,
+		MaxStreams: entry.maxStreams,
+		ListenAddr: entry.listenAddr,
+	}, true
+}
+
+// ListPorts returns a snapshot of all port mappings.
+func (r *PortRouter) ListPorts() []PortInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]PortInfo, 0, len(r.portMap))
+	for port, entry := range r.portMap {
+		out = append(out, PortInfo{
+			Port:       port,
+			CustomerID: entry.customerID,
+			Service:    entry.service,
+			MaxStreams: entry.maxStreams,
+			ListenAddr: entry.listenAddr,
+		})
+	}
+	return out
 }
 
 // RemovePortMapping releases a previously assigned port mapping.

--- a/pkg/relay/router_impl_test.go
+++ b/pkg/relay/router_impl_test.go
@@ -30,7 +30,7 @@ func TestPortRouter_AddAndLookup(t *testing.T) {
 	reg := NewMemoryRegistry(slog.Default())
 	router := NewPortRouter(reg, slog.Default())
 
-	require.NoError(t, router.AddPortMapping("customer-001", 8080, "http", 0))
+	require.NoError(t, router.AddPortMapping("customer-001", 8080, "http", "", 0))
 
 	cid, svc, ok := router.LookupPort(8080)
 	assert.True(t, ok)
@@ -50,7 +50,7 @@ func TestPortRouter_RemovePortMapping(t *testing.T) {
 	reg := NewMemoryRegistry(slog.Default())
 	router := NewPortRouter(reg, slog.Default())
 
-	require.NoError(t, router.AddPortMapping("customer-001", 8080, "http", 0))
+	require.NoError(t, router.AddPortMapping("customer-001", 8080, "http", "", 0))
 	require.NoError(t, router.RemovePortMapping("customer-001", 8080))
 
 	_, _, ok := router.LookupPort(8080)
@@ -61,7 +61,7 @@ func TestPortRouter_RemoveWrongCustomer(t *testing.T) {
 	reg := NewMemoryRegistry(slog.Default())
 	router := NewPortRouter(reg, slog.Default())
 
-	require.NoError(t, router.AddPortMapping("customer-001", 8080, "http", 0))
+	require.NoError(t, router.AddPortMapping("customer-001", 8080, "http", "", 0))
 	err := router.RemovePortMapping("customer-002", 8080)
 	assert.Error(t, err)
 }
@@ -69,7 +69,7 @@ func TestPortRouter_RemoveWrongCustomer(t *testing.T) {
 func TestPortRouter_RouteNoAgent(t *testing.T) {
 	reg := NewMemoryRegistry(slog.Default())
 	router := NewPortRouter(reg, slog.Default())
-	router.AddPortMapping("customer-001", 8080, "http", 0) //nolint:errcheck // test setup, error not relevant
+	router.AddPortMapping("customer-001", 8080, "http", "", 0) //nolint:errcheck // test setup, error not relevant
 
 	c1, c2 := net.Pipe()
 	defer c1.Close()
@@ -87,7 +87,7 @@ func TestPortRouter_RouteEndToEnd(t *testing.T) {
 	// Set up: registry, router, agent mux pair, echo server
 	reg := NewMemoryRegistry(slog.Default())
 	router := NewPortRouter(reg, slog.Default())
-	router.AddPortMapping("customer-001", 8080, "echo", 0) //nolint:errcheck // test setup, error not relevant
+	router.AddPortMapping("customer-001", 8080, "echo", "", 0) //nolint:errcheck // test setup, error not relevant
 
 	// Create relay<->agent mux pair
 	relayConn, agentConn := net.Pipe()
@@ -196,7 +196,7 @@ func TestPortRouter_StreamOpenPayloadCarriesServiceName(t *testing.T) {
 func TestPortRouter_StreamLimitEnforced(t *testing.T) {
 	reg := NewMemoryRegistry(slog.Default())
 	router := NewPortRouter(reg, slog.Default())
-	router.AddPortMapping("customer-001", 8080, "echo", 1) //nolint:errcheck // test setup, error not relevant
+	router.AddPortMapping("customer-001", 8080, "echo", "", 1) //nolint:errcheck // test setup, error not relevant
 
 	// Create relay<->agent mux pair
 	relayConn, agentConn := net.Pipe()
@@ -235,7 +235,7 @@ func TestPortRouter_StreamLimitEnforced(t *testing.T) {
 func TestPortRouter_StreamLimitZeroIsUnlimited(t *testing.T) {
 	reg := NewMemoryRegistry(slog.Default())
 	router := NewPortRouter(reg, slog.Default())
-	router.AddPortMapping("customer-001", 8080, "echo", 0) //nolint:errcheck // test setup, error not relevant
+	router.AddPortMapping("customer-001", 8080, "echo", "", 0) //nolint:errcheck // test setup, error not relevant
 
 	relayConn, agentConn := net.Pipe()
 	relayMux := protocol.NewMuxSession(relayConn, protocol.RoleRelay, testMuxConfig())

--- a/pkg/relay/server_impl.go
+++ b/pkg/relay/server_impl.go
@@ -51,7 +51,7 @@ func (s *Relay) Start(ctx context.Context) error {
 	// Register port mappings from config.
 	for port, entry := range s.portIndex.Entries {
 		if err := s.router.AddPortMapping(
-			entry.CustomerID, port, entry.Service, entry.MaxStreams,
+			entry.CustomerID, port, entry.Service, entry.ListenAddr, entry.MaxStreams,
 		); err != nil {
 			return fmt.Errorf("relay: add port mapping: %w", err)
 		}


### PR DESCRIPTION
## Summary

Phase 1 of the usability refinement plan (plans/atlax-usability-refinement-plan.md). Fixes latent bugs, closes trivial admin API gaps, and adds pre-flight validation. No architectural decisions, no protocol changes.

## Changes

### fix(auth): cert hot-reload via atomic GetCertificate callback (A1)

`WatchForRotation` was implemented in `pkg/auth/certs_impl.go` with tests and documented in runbooks -- but was **never called from `cmd/relay/main.go` or `cmd/agent/main.go`**. Cert rotation required a restart despite docs claiming otherwise.

Changed `Configurator` to use `GetCertificate` / `GetClientCertificate` callbacks backed by `atomic.Pointer[tls.Certificate]`. Added `Reload()` method. Both relay and agent now start a `WatchForRotation` goroutine that polls every 24h and swaps the cert atomically.

### feat(admin): /readyz, GET /ports/{port}, GET /agents/{id}, expose fields (A2, A3, A4, B1, B2, B5)

- **`GET /readyz`** registered (was referenced in docs but not wired)
- **`GET /ports/{port}`** for single-port inspection
- **`GET /agents/{customerID}`** for single-agent inspection
- `PortResponse` now includes `listen_addr` and `max_streams` (were hidden in `portEntry` but not exposed)
- `POST /ports` logs WARN that the change is not persisted
- `DELETE /ports` logs WARN to also remove from relay.yaml
- Fixed misleading "may be config-started" warning (config-started listeners ARE registered)
- `AddPortMapping` extended with `listenAddr` parameter; `ListPorts()` / `GetPort()` router methods for clean admin API access

### feat(daemon): --validate flag, chain cert check (A5, D8)

- `atlax-relay --validate relay.yaml` and `atlax-agent --validate agent.yaml` dry-run config checks
- Pre-flight validates that `cert_file` is a chain cert (not a bare leaf). Error message explains what's wrong and how to fix it.

### docs: Prometheus conflict, remove aspirational enterprise content (A6, A7)

- `configs/relay.example.yaml` warns about port 9090 conflict with Prometheus
- `docs/operations/certificate-ops.md` stripped of enterprise functionality that was described as community features (CSR renewal endpoint, CRL fetching, OCSP). Replaced with accurate community cert rotation workflow.

## Test plan

- [x] 6 new tests: `TestAdmin_ReadyCheck`, `TestAdmin_GetPort_Found/NotFound`, `TestAdmin_ListPorts_IncludesListenAddrAndMaxStreams`, `TestAdmin_GetAgent_Found/NotFound`
- [x] 4 new tests: `TestValidateChainCertFile_Chain/BareCert/Missing/Empty`
- [x] 1 new test: `TestConfigurator_Reload_SwapsCertificate`
- [x] 2 updated tests: `TestConfigurator_*_HasCert` updated for GetCertificate callback
- [x] All existing tests pass with `-race` (except pre-existing flaky `TestAdmin_CreateAndListPort` on macOS)
- [x] `go vet ./...` clean
- [ ] CI lint + govulncheck (pending CI run)