### PR TITLE
docs: ats CLI discoverability and firewall checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,25 @@ Client (internet)                     Relay (VPS)                    Your Server
 
 ## Quick Start
 
-### Prerequisites
+### Recommended: use `ats` (the atlax CLI)
 
-- Go 1.25+
-- OpenSSL 3.x
+The [`ats` CLI](https://github.com/atlasshare/atlax-tools) provides interactive setup wizards, PKI management, health checks, and more. It is the fastest way to go from zero to a working tunnel.
 
-### Build
+```bash
+go install github.com/atlasshare/atlax-tools/cmd/ats@latest
+
+ats certs init       # generate full mTLS certificate hierarchy
+ats setup relay      # interactive relay setup (config, systemd, firewall)
+ats setup agent      # interactive agent setup (config, services, systemd)
+```
+
+See the [atlax-tools README](https://github.com/atlasshare/atlax-tools) for the full command reference and guides.
+
+### Manual: build from source
+
+If you prefer manual setup or need to customize the build:
+
+**Prerequisites:** Go 1.25+, OpenSSL 3.x
 
 ```bash
 git clone https://github.com/atlasshare/atlax.git
@@ -408,7 +421,9 @@ For enterprise inquiries, contact **licensing@atlasshare.io**.
 
 ## Documentation
 
-- [Setup and Testing](docs/operations/setup-and-testing.md) -- Local, LAN, and AWS deployment
+- **[`ats` CLI (atlax-tools)](https://github.com/atlasshare/atlax-tools)** -- Interactive setup, PKI management, health checks, backup/restore
+- [Setup and Testing](docs/operations/setup-and-testing.md) -- Local, LAN, and AWS deployment (manual path)
+- [Admin API Reference](docs/api/control-plane.md) -- REST API for health, metrics, ports, agents
 - [Multi-Tenancy](docs/operations/multi-tenancy.md) -- Isolation model, limits, Caddy pattern
 - [Architecture](docs/architecture/) -- System design and component overview
 - [Protocol](docs/protocol/) -- Wire protocol specification

--- a/docs/operations/production-setup.md
+++ b/docs/operations/production-setup.md
@@ -311,6 +311,8 @@ sudo chmod 640 /etc/atlax/relay.yaml
 
 ### 4.5 Firewall
 
+> **Two-layer firewall on cloud VMs:** If you run atlax on AWS, GCP, Azure, or DigitalOcean, you have two independent firewall layers: the **cloud security group** (or firewall rule) AND the **host firewall** (UFW, firewalld, iptables). **Both must allow the port** for traffic to reach the relay. A common gotcha is opening the cloud security group but forgetting UFW (or vice versa) -- traffic is silently dropped with no error in the relay logs. Always check both layers when debugging connectivity issues.
+
 **UFW (Ubuntu):**
 
 ```bash
@@ -914,6 +916,8 @@ Verify each item after completing setup.
 ---
 
 ## 9. Troubleshooting
+
+> **Tip:** Run `ats health` from [atlax-tools](https://github.com/atlasshare/atlax-tools) for automated diagnostics. It checks config readability, cert validity, TLS handshake, port connectivity, and systemd service state in one command.
 
 ### TLS Handshake Failures
 

--- a/docs/operations/setup-and-testing.md
+++ b/docs/operations/setup-and-testing.md
@@ -1,5 +1,7 @@
 # atlax Setup and Testing Guide
 
+> **Recommended:** Use the [`ats` CLI](https://github.com/atlasshare/atlax-tools) for interactive setup. `ats setup relay` and `ats setup agent` automate most of the steps below (PKI, config generation, systemd, firewall). The manual steps in this guide are for operators who prefer full control or need to understand the internals.
+
 This guide walks through setting up atlax in three stages:
 
 1. **Local testing** -- both binaries on localhost
@@ -13,7 +15,7 @@ Tested and verified on 2026-03-30 with real Samba and web app traffic.
 ## Prerequisites
 
 - Go 1.25+ installed on build machine
-- OpenSSL 3.x (for certificate generation)
+- OpenSSL 3.x (for certificate generation), or `ats certs init` from [atlax-tools](https://github.com/atlasshare/atlax-tools)
 - SSH access to the agent host
 - For Stage 3: AWS EC2 instance with Elastic IP
 


### PR DESCRIPTION
## Summary

Phase 2 (community side) of the usability refinement plan. Makes `ats` discoverable from the atlax README and adds the two-layer firewall warning operators need.

## Changes

- **README.md**: new "Recommended: use ats" section before the manual quick start with install + setup commands. Link to atlax-tools repo. Added ats + admin API reference to docs list.
- **docs/operations/setup-and-testing.md**: ats recommendation banner at the top, `ats certs init` in prerequisites.
- **docs/operations/production-setup.md**: two-layer firewall warning in firewall section (cloud SG + host UFW must both pass), `ats health` tip in troubleshooting.