### PR TITLE
feat(audit): wire Emitter into AdminServer for admin API audit trail

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -135,6 +135,7 @@ func run() error {
 		Router:         router,
 		ClientListener: clientListener,
 		Logger:         logger,
+		Emitter:        emitter,
 	})
 	go func() {
 		if adminErr := admin.Start(ctx); adminErr != nil {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -128,7 +128,7 @@ func run() error {
 	})
 
 	// Start admin server (health check + metrics + CRUD API)
-	admin := relay.NewAdminServer(relay.AdminConfig{
+	admin := relay.NewAdminServer(&relay.AdminConfig{
 		Addr:           cfg.Server.AdminAddr,
 		SocketPath:     cfg.Server.AdminSocket,
 		Registry:       registry,

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -19,6 +19,13 @@ const (
 	ActionCertRotation      Action = "cert.rotation"
 	ActionGoAway            Action = "connection.goaway"
 	ActionHeartbeatTimeout  Action = "agent.heartbeat_timeout"
+
+	// Admin API actions — operator-initiated mutations via the control plane.
+	ActionAdminPortAdded         Action = "admin.port_added"
+	ActionAdminPortRemoved       Action = "admin.port_removed"
+	ActionAdminPortUpdated       Action = "admin.port_updated"
+	ActionAdminAgentDisconnected Action = "admin.agent_disconnected"
+	ActionAdminReload            Action = "admin.reload"
 )
 
 // Event is an immutable record of a single auditable occurrence.

--- a/pkg/relay/admin.go
+++ b/pkg/relay/admin.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/atlasshare/atlax/pkg/audit"
 )
 
 // AdminServer serves the admin API: health check, Prometheus metrics,
@@ -21,6 +23,7 @@ type AdminServer struct {
 	registry       AgentRegistry
 	router         *PortRouter
 	clientListener *ClientListener
+	emitter        audit.Emitter
 	logger         *slog.Logger
 	server         *http.Server
 	socketPath     string
@@ -42,6 +45,9 @@ type AdminConfig struct {
 	Router         *PortRouter
 	ClientListener *ClientListener
 	Logger         *slog.Logger
+	// Emitter receives audit events for mutating admin API operations.
+	// If nil, mutations are logged but not audited.
+	Emitter audit.Emitter
 }
 
 // HealthResponse is the JSON body returned by /healthz.
@@ -93,6 +99,7 @@ func NewAdminServer(cfg AdminConfig) *AdminServer {
 		registry:       cfg.Registry,
 		router:         cfg.Router,
 		clientListener: cfg.ClientListener,
+		emitter:        cfg.Emitter,
 		logger:         cfg.Logger,
 		socketPath:     cfg.SocketPath,
 		startTime:      time.Now(),
@@ -358,6 +365,10 @@ func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
 		"service", req.Service,
 		"listen_addr", addr)
 
+	a.emitAudit(r.Context(), audit.ActionAdminPortAdded,
+		fmt.Sprintf("%d", req.Port), req.CustomerID,
+		map[string]string{"service": req.Service, "listen_addr": addr})
+
 	w.WriteHeader(http.StatusCreated)
 	writeJSON(w, PortResponse{
 		Port:       req.Port,
@@ -368,7 +379,7 @@ func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (a *AdminServer) deletePort(w http.ResponseWriter, _ *http.Request, port int) {
+func (a *AdminServer) deletePort(w http.ResponseWriter, r *http.Request, port int) {
 	customerID, _, ok := a.router.LookupPort(port)
 	if !ok {
 		http.Error(w, `{"error":"port not found"}`, http.StatusNotFound)
@@ -394,6 +405,9 @@ func (a *AdminServer) deletePort(w http.ResponseWriter, _ *http.Request, port in
 	a.logger.Warn("admin: port mapping removed at runtime; also remove from relay.yaml to prevent reappearance on restart",
 		"port", port,
 		"customer_id", customerID)
+
+	a.emitAudit(r.Context(), audit.ActionAdminPortRemoved,
+		fmt.Sprintf("%d", port), customerID, nil)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -472,10 +486,31 @@ func (a *AdminServer) deleteAgent(w http.ResponseWriter, r *http.Request, custom
 	a.logger.Info("admin: agent disconnected",
 		"customer_id", customerID)
 
+	a.emitAudit(r.Context(), audit.ActionAdminAgentDisconnected,
+		customerID, customerID, nil)
+
 	w.WriteHeader(http.StatusNoContent)
 }
 
 // --- Helpers ---
+
+// emitAudit emits a best-effort audit event for a mutating admin operation.
+// target is the resource being acted on (port number or customer ID).
+// No-op if the emitter was not configured.
+func (a *AdminServer) emitAudit(ctx context.Context, action audit.Action, target, customerID string, metadata map[string]string) {
+	if a.emitter == nil {
+		return
+	}
+	//nolint:errcheck // best-effort audit
+	a.emitter.Emit(ctx, audit.Event{
+		Action:     action,
+		Actor:      "admin-api",
+		Target:     target,
+		Timestamp:  time.Now(),
+		CustomerID: customerID,
+		Metadata:   metadata,
+	})
+}
 
 func writeError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/relay/admin.go
+++ b/pkg/relay/admin.go
@@ -94,7 +94,7 @@ type PortCreateRequest struct {
 }
 
 // NewAdminServer creates an admin server with the full API.
-func NewAdminServer(cfg AdminConfig) *AdminServer {
+func NewAdminServer(cfg *AdminConfig) *AdminServer {
 	a := &AdminServer{
 		registry:       cfg.Registry,
 		router:         cfg.Router,

--- a/pkg/relay/admin_test.go
+++ b/pkg/relay/admin_test.go
@@ -9,12 +9,71 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlasshare/atlax/pkg/audit"
 )
+
+// captureEmitter is a test-local audit.Emitter that records all emitted events.
+type captureEmitter struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (c *captureEmitter) Emit(_ context.Context, event audit.Event) error {
+	c.mu.Lock()
+	c.events = append(c.events, event)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *captureEmitter) Close() error { return nil }
+
+func (c *captureEmitter) snapshot() []audit.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]audit.Event, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+// testAdminServerWithEmitter returns an admin server wired to a captureEmitter.
+func testAdminServerWithEmitter(t *testing.T) (addr string, reg *MemoryRegistry, router *PortRouter, cl *ClientListener, emitter *captureEmitter) {
+	t.Helper()
+	reg = NewMemoryRegistry(slog.Default())
+	router = NewPortRouter(reg, slog.Default())
+	cl = NewClientListener(ClientListenerConfig{Router: router, Logger: slog.Default()})
+	emitter = &captureEmitter{}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr = ln.Addr().String()
+	ln.Close()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+
+	admin := NewAdminServer(AdminConfig{
+		Addr:           addr,
+		Registry:       reg,
+		Router:         router,
+		ClientListener: cl,
+		Logger:         slog.Default(),
+		Emitter:        emitter,
+	})
+
+	go func() {
+		admin.Start(ctx) //nolint:errcheck // stopped via ctx cancel
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	t.Cleanup(cancelFn)
+	return addr, reg, router, cl, emitter
+}
 
 func testAdminServer(t *testing.T) (addr string, reg *MemoryRegistry, router *PortRouter, cl *ClientListener) {
 	t.Helper()
@@ -644,4 +703,126 @@ func TestAdmin_EmptySocketPath(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// --- Audit emission tests ---
+
+func TestAdmin_AuditEmission_CreatePort(t *testing.T) {
+	addr, _, router, cl, emitter := testAdminServerWithEmitter(t)
+
+	// Bind a real listener so StartPort succeeds.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"port":        port,
+		"customer_id": "customer-audit-001",
+		"service":     "samba",
+	})
+	resp, err := http.Post("http://"+addr+"/ports", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// Clean up the started listener.
+	cl.StopPort(port)           //nolint:errcheck // best-effort cleanup
+	router.RemovePortMapping("customer-audit-001", port) //nolint:errcheck
+
+	events := emitter.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, audit.ActionAdminPortAdded, events[0].Action)
+	assert.Equal(t, "admin-api", events[0].Actor)
+	assert.Equal(t, fmt.Sprintf("%d", port), events[0].Target)
+	assert.Equal(t, "customer-audit-001", events[0].CustomerID)
+	assert.Equal(t, "samba", events[0].Metadata["service"])
+}
+
+func TestAdmin_AuditEmission_DeletePort(t *testing.T) {
+	addr, _, router, cl, emitter := testAdminServerWithEmitter(t)
+
+	// Pre-register a port mapping and a listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	require.NoError(t, router.AddPortMapping("customer-audit-002", port, "http", "127.0.0.1", 0))
+	ctx := context.Background()
+	go cl.StartPort(ctx, fmt.Sprintf("127.0.0.1:%d", port), port) //nolint:errcheck
+	time.Sleep(50 * time.Millisecond)
+
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("http://%s/ports/%d", addr, port), nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, audit.ActionAdminPortRemoved, events[0].Action)
+	assert.Equal(t, "admin-api", events[0].Actor)
+	assert.Equal(t, fmt.Sprintf("%d", port), events[0].Target)
+	assert.Equal(t, "customer-audit-002", events[0].CustomerID)
+}
+
+func TestAdmin_AuditEmission_DeleteAgent(t *testing.T) {
+	addr, reg, _, _, emitter := testAdminServerWithEmitter(t)
+
+	conn, agentMux := testConnectionPair("customer-audit-003")
+	defer conn.Close()
+	defer agentMux.Close()
+	require.NoError(t, reg.Register(context.Background(), "customer-audit-003", conn))
+
+	req, _ := http.NewRequest(http.MethodDelete, "http://"+addr+"/agents/customer-audit-003", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, audit.ActionAdminAgentDisconnected, events[0].Action)
+	assert.Equal(t, "admin-api", events[0].Actor)
+	assert.Equal(t, "customer-audit-003", events[0].Target)
+	assert.Equal(t, "customer-audit-003", events[0].CustomerID)
+}
+
+func TestAdmin_AuditEmission_NilEmitter_NoPanic(t *testing.T) {
+	// AdminServer with no Emitter configured must not panic on mutations.
+	reg := NewMemoryRegistry(slog.Default())
+	router := NewPortRouter(reg, slog.Default())
+	cl := NewClientListener(ClientListenerConfig{Router: router, Logger: slog.Default()})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	adminAddr := ln.Addr().String()
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	admin := NewAdminServer(AdminConfig{
+		Addr:           adminAddr,
+		Registry:       reg,
+		Router:         router,
+		ClientListener: cl,
+		Logger:         slog.Default(),
+		// Emitter intentionally nil
+	})
+	go admin.Start(ctx) //nolint:errcheck
+	time.Sleep(100 * time.Millisecond)
+
+	// Register then delete an agent — should not panic.
+	conn, agentMux := testConnectionPair("customer-nil-emitter")
+	defer conn.Close()
+	defer agentMux.Close()
+	require.NoError(t, reg.Register(ctx, "customer-nil-emitter", conn))
+
+	req, _ := http.NewRequest(http.MethodDelete, "http://"+adminAddr+"/agents/customer-nil-emitter", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }

--- a/pkg/relay/admin_test.go
+++ b/pkg/relay/admin_test.go
@@ -25,7 +25,7 @@ type captureEmitter struct {
 	events []audit.Event
 }
 
-func (c *captureEmitter) Emit(_ context.Context, event audit.Event) error {
+func (c *captureEmitter) Emit(_ context.Context, event audit.Event) error { //nolint:gocritic // hugeParam: signature must match audit.Emitter interface
 	c.mu.Lock()
 	c.events = append(c.events, event)
 	c.mu.Unlock()
@@ -727,8 +727,8 @@ func TestAdmin_AuditEmission_CreatePort(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Clean up the started listener.
-	cl.StopPort(port)           //nolint:errcheck // best-effort cleanup
-	router.RemovePortMapping("customer-audit-001", port) //nolint:errcheck
+	cl.StopPort(port)                                    //nolint:errcheck // best-effort cleanup
+	router.RemovePortMapping("customer-audit-001", port) //nolint:errcheck // best-effort cleanup
 
 	events := emitter.snapshot()
 	require.Len(t, events, 1)
@@ -750,10 +750,10 @@ func TestAdmin_AuditEmission_DeletePort(t *testing.T) {
 
 	require.NoError(t, router.AddPortMapping("customer-audit-002", port, "http", "127.0.0.1", 0))
 	ctx := context.Background()
-	go cl.StartPort(ctx, fmt.Sprintf("127.0.0.1:%d", port), port) //nolint:errcheck
+	go cl.StartPort(ctx, fmt.Sprintf("127.0.0.1:%d", port), port) //nolint:errcheck // test listener, error not relevant
 	time.Sleep(50 * time.Millisecond)
 
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("http://%s/ports/%d", addr, port), nil)
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("http://%s/ports/%d", addr, port), http.NoBody)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -775,7 +775,7 @@ func TestAdmin_AuditEmission_DeleteAgent(t *testing.T) {
 	defer agentMux.Close()
 	require.NoError(t, reg.Register(context.Background(), "customer-audit-003", conn))
 
-	req, _ := http.NewRequest(http.MethodDelete, "http://"+addr+"/agents/customer-audit-003", nil)
+	req, _ := http.NewRequest(http.MethodDelete, "http://"+addr+"/agents/customer-audit-003", http.NoBody)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -811,7 +811,7 @@ func TestAdmin_AuditEmission_NilEmitter_NoPanic(t *testing.T) {
 		Logger:         slog.Default(),
 		// Emitter intentionally nil
 	})
-	go admin.Start(ctx) //nolint:errcheck
+	go admin.Start(ctx) //nolint:errcheck // admin server error is logged internally; not relevant to this test
 	time.Sleep(100 * time.Millisecond)
 
 	// Register then delete an agent — should not panic.
@@ -820,7 +820,7 @@ func TestAdmin_AuditEmission_NilEmitter_NoPanic(t *testing.T) {
 	defer agentMux.Close()
 	require.NoError(t, reg.Register(ctx, "customer-nil-emitter", conn))
 
-	req, _ := http.NewRequest(http.MethodDelete, "http://"+adminAddr+"/agents/customer-nil-emitter", nil)
+	req, _ := http.NewRequest(http.MethodDelete, "http://"+adminAddr+"/agents/customer-nil-emitter", http.NoBody)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/pkg/relay/admin_test.go
+++ b/pkg/relay/admin_test.go
@@ -57,7 +57,7 @@ func testAdminServerWithEmitter(t *testing.T) (addr string, reg *MemoryRegistry,
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		Addr:           addr,
 		Registry:       reg,
 		Router:         router,
@@ -88,7 +88,7 @@ func testAdminServer(t *testing.T) (addr string, reg *MemoryRegistry, router *Po
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		Addr:           addr,
 		Registry:       reg,
 		Router:         router,
@@ -525,7 +525,7 @@ func TestAdmin_StartUnixSocket(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		SocketPath:     socketPath,
 		Registry:       reg,
 		Router:         router,
@@ -569,7 +569,7 @@ func TestAdmin_StartBothTCPAndUnix(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		Addr:           tcpAddr,
 		SocketPath:     socketPath,
 		Registry:       reg,
@@ -619,7 +619,7 @@ func TestAdmin_SocketFailureFallsBackToTCP(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// Unwritable socket path -- should warn and fall back to TCP.
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		Addr:           tcpAddr,
 		SocketPath:     "/nonexistent/dir/atlax.sock",
 		Registry:       reg,
@@ -658,7 +658,7 @@ func TestAdmin_SocketFailureOnlySocket(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// Socket-only mode (no Addr) with unwritable path -- should fail.
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		SocketPath:     "/nonexistent/dir/atlax.sock",
 		Registry:       reg,
 		Router:         router,
@@ -685,7 +685,7 @@ func TestAdmin_EmptySocketPath(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// Empty socket path -- TCP only, no socket attempted.
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		Addr:           tcpAddr,
 		SocketPath:     "",
 		Registry:       reg,
@@ -803,7 +803,7 @@ func TestAdmin_AuditEmission_NilEmitter_NoPanic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	admin := NewAdminServer(AdminConfig{
+	admin := NewAdminServer(&AdminConfig{
 		Addr:           adminAddr,
 		Registry:       reg,
 		Router:         router,


### PR DESCRIPTION
## Summary

- Adds five `ActionAdmin*` constants to `pkg/audit/audit.go` (`port_added`, `port_removed`, `port_updated`, `agent_disconnected`, `reload`) for use across Phase 3
- Wires `audit.Emitter` into `AdminServer` and `AdminConfig` — previously the struct had no emitter field at all
- Passes the existing `SlogEmitter` from `cmd/relay/main.go` into the admin server (no new emitter instantiated)
- Adds `emitAudit` private helper following the pattern already established in `AgentListener.emitAudit`
- Emits structured audit events in the three mutating admin endpoints: `POST /ports`, `DELETE /ports/{port}`, `DELETE /agents/{id}`
- Emitter is optional — `nil` emitter is a no-op (no panic), preserving backward compatibility

## Why

`AdminServer` had no `Emitter` field. All three mutating admin operations — adding a port mapping, removing a port mapping, and force-disconnecting a customer agent — were logging to raw `slog` only. These are irreversible operator actions that must appear in the audit trail, and are prerequisites for the `GET /events` SSE endpoint (Phase 3 / F1).

Tracked as H1+H2+H3 in `plans/phase3-runtime-operator-plan.md`. Enterprise issue filed at atlasshare/atlax-enterprise#15.

## Files changed

- `pkg/audit/audit.go` — 5 new Action constants
- `pkg/relay/admin.go` — `Emitter` field, `emitAudit` helper, emit calls in 3 handlers
- `pkg/relay/admin_test.go` — `captureEmitter` type, `testAdminServerWithEmitter` helper, 4 new tests
- `cmd/relay/main.go` — `Emitter: emitter` added to `AdminConfig` literal

## Test plan

- [ ] `go test -race ./pkg/...` — all 6 packages green
- [ ] `TestAdmin_AuditEmission_CreatePort` — POST /ports emits `admin.port_added` with correct action, actor, target, customer_id, metadata
- [ ] `TestAdmin_AuditEmission_DeletePort` — DELETE /ports/{port} emits `admin.port_removed`
- [ ] `TestAdmin_AuditEmission_DeleteAgent` — DELETE /agents/{id} emits `admin.agent_disconnected`
- [ ] `TestAdmin_AuditEmission_NilEmitter_NoPanic` — nil Emitter does not panic on any mutation