### PR TITLE
feat(relay): C1 sidecar JSON store for runtime port persistence

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"net"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/atlasshare/atlax/pkg/audit"
@@ -117,20 +119,58 @@ func run() error {
 				"path", cfg.Server.StorePath, "error", loadErr)
 			sidecarStore = nil
 		} else {
+			seen := make(map[int]bool, len(sidecarData.Ports))
+			merged := 0
 			for _, sp := range sidecarData.Ports {
+				// Validate port range.
+				if sp.Port <= 0 || sp.Port > 65535 {
+					logger.Warn("relay: sidecar: skipping entry with invalid port", "port", sp.Port)
+					continue
+				}
+				// Validate required fields.
+				if sp.CustomerID == "" || sp.Service == "" {
+					logger.Warn("relay: sidecar: skipping entry with missing customer_id or service",
+						"port", sp.Port)
+					continue
+				}
+				// Validate listen address when set.
+				if sp.ListenAddr != "" && net.ParseIP(sp.ListenAddr) == nil {
+					logger.Warn("relay: sidecar: skipping entry with invalid listen_addr",
+						"port", sp.Port, "listen_addr", sp.ListenAddr)
+					continue
+				}
+				// Validate max_streams.
+				if sp.MaxStreams < 0 {
+					logger.Warn("relay: sidecar: skipping entry with negative max_streams",
+						"port", sp.Port)
+					continue
+				}
+				// Detect duplicates within the sidecar itself.
+				if seen[sp.Port] {
+					logger.Warn("relay: sidecar: duplicate port, skipping", "port", sp.Port)
+					continue
+				}
+				seen[sp.Port] = true
+				// relay.yaml entries always win.
 				if _, exists := portIndex.Entries[sp.Port]; exists {
-					continue // relay.yaml entry takes precedence
+					continue
+				}
+				listenAddr := sp.ListenAddr
+				if listenAddr == "" {
+					listenAddr = "0.0.0.0"
 				}
 				portIndex.Entries[sp.Port] = config.PortIndexEntry{
 					CustomerID: sp.CustomerID,
 					Service:    sp.Service,
-					ListenAddr: sp.ListenAddr,
+					ListenAddr: listenAddr,
 					MaxStreams:  sp.MaxStreams,
 				}
+				merged++
 			}
 			logger.Info("relay: sidecar loaded",
 				"path", cfg.Server.StorePath,
-				"ports", len(sidecarData.Ports))
+				"total", len(sidecarData.Ports),
+				"merged", merged)
 		}
 	}
 

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -106,6 +106,34 @@ func run() error {
 		}
 	}
 
+	// Load sidecar and merge runtime port additions into the port index.
+	// Sidecar entries that conflict with relay.yaml are skipped (relay.yaml wins).
+	var sidecarStore *relay.SidecarStore
+	if cfg.Server.StorePath != "" {
+		sidecarStore = relay.NewSidecarStore(cfg.Server.StorePath)
+		sidecarData, loadErr := sidecarStore.Load()
+		if loadErr != nil {
+			logger.Warn("relay: sidecar load error, starting without persisted runtime ports",
+				"path", cfg.Server.StorePath, "error", loadErr)
+			sidecarStore = nil
+		} else {
+			for _, sp := range sidecarData.Ports {
+				if _, exists := portIndex.Entries[sp.Port]; exists {
+					continue // relay.yaml entry takes precedence
+				}
+				portIndex.Entries[sp.Port] = config.PortIndexEntry{
+					CustomerID: sp.CustomerID,
+					Service:    sp.Service,
+					ListenAddr: sp.ListenAddr,
+					MaxStreams:  sp.MaxStreams,
+				}
+			}
+			logger.Info("relay: sidecar loaded",
+				"path", cfg.Server.StorePath,
+				"ports", len(sidecarData.Ports))
+		}
+	}
+
 	server := relay.NewRelay(relay.ServerDeps{
 		AgentListener:  agentListener,
 		ClientListener: clientListener,
@@ -136,6 +164,7 @@ func run() error {
 		ClientListener: clientListener,
 		Logger:         logger,
 		Emitter:        emitter,
+		Store:          sidecarStore,
 	})
 	go func() {
 		if adminErr := admin.Start(ctx); adminErr != nil {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -163,7 +163,7 @@ func run() error {
 					CustomerID: sp.CustomerID,
 					Service:    sp.Service,
 					ListenAddr: listenAddr,
-					MaxStreams:  sp.MaxStreams,
+					MaxStreams: sp.MaxStreams,
 				}
 				merged++
 			}

--- a/configs/relay.example.yaml
+++ b/configs/relay.example.yaml
@@ -30,6 +30,13 @@ server:
   # Grace period for draining streams during shutdown (GOAWAY)
   shutdown_grace_period: 30s
 
+  # Path to the sidecar JSON file for persisting runtime port mutations.
+  # When set, ports added or removed via the admin API survive process
+  # restarts without requiring relay.yaml to be edited. relay.yaml
+  # entries always take precedence over sidecar entries on startup.
+  # Recommended path: /var/lib/atlax/relay-state.json
+  # store_path: /var/lib/atlax/relay-state.json
+
 tls:
   # Relay server certificate (signed by Relay Intermediate CA)
   # Use chain cert (relay.crt + relay-ca.crt), not bare cert.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ type ServerConfig struct {
 	ShutdownGracePeriod time.Duration `yaml:"shutdown_grace_period"`
 	// StorePath is the path to the sidecar JSON file that persists runtime
 	// port mutations across process restarts. If empty, runtime mutations
-	// are not persisted (existing behaviour).
+	// are not persisted (existing behavior).
 	StorePath string `yaml:"store_path"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,10 @@ type ServerConfig struct {
 	MaxStreamsPerAgent  int           `yaml:"max_streams_per_agent"`
 	IdleTimeout         time.Duration `yaml:"idle_timeout"`
 	ShutdownGracePeriod time.Duration `yaml:"shutdown_grace_period"`
+	// StorePath is the path to the sidecar JSON file that persists runtime
+	// port mutations across process restarts. If empty, runtime mutations
+	// are not persisted (existing behaviour).
+	StorePath string `yaml:"store_path"`
 }
 
 // TLSPaths points to the PEM files needed for mTLS.

--- a/pkg/relay/admin.go
+++ b/pkg/relay/admin.go
@@ -160,7 +160,10 @@ func (a *AdminServer) Start(ctx context.Context) error {
 			a.logger.Warn("admin: unix socket failed, continuing with TCP only",
 				"path", a.socketPath, "error", err)
 		} else {
-			os.Chmod(a.socketPath, 0o660) //nolint:errcheck // best-effort permissions
+			if chmodErr := os.Chmod(a.socketPath, 0o600); chmodErr != nil {
+			a.logger.Warn("admin: failed to set socket permissions",
+				"path", a.socketPath, "error", chmodErr)
+		}
 			a.logger.Info("relay: admin socket started", "path", a.socketPath)
 
 			if a.server.Addr == "" {
@@ -322,8 +325,22 @@ func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Port <= 0 || req.CustomerID == "" || req.Service == "" {
-		http.Error(w, `{"error":"port, customer_id, and service are required"}`, http.StatusBadRequest)
+	if req.Port <= 0 || req.Port > 65535 {
+		http.Error(w, `{"error":"port must be between 1 and 65535"}`, http.StatusBadRequest)
+		return
+	}
+	if req.CustomerID == "" || req.Service == "" {
+		http.Error(w, `{"error":"customer_id and service are required"}`, http.StatusBadRequest)
+		return
+	}
+	if req.ListenAddr != "" {
+		if net.ParseIP(req.ListenAddr) == nil {
+			http.Error(w, `{"error":"listen_addr must be a valid IP address"}`, http.StatusBadRequest)
+			return
+		}
+	}
+	if req.MaxStreams < 0 {
+		http.Error(w, `{"error":"max_streams must be non-negative"}`, http.StatusBadRequest)
 		return
 	}
 

--- a/pkg/relay/admin.go
+++ b/pkg/relay/admin.go
@@ -24,6 +24,7 @@ type AdminServer struct {
 	router         *PortRouter
 	clientListener *ClientListener
 	emitter        audit.Emitter
+	store          *SidecarStore
 	logger         *slog.Logger
 	server         *http.Server
 	socketPath     string
@@ -48,6 +49,9 @@ type AdminConfig struct {
 	// Emitter receives audit events for mutating admin API operations.
 	// If nil, mutations are logged but not audited.
 	Emitter audit.Emitter
+	// Store persists runtime port mutations to the sidecar JSON file.
+	// If nil, mutations are not persisted (relay.yaml remains authoritative).
+	Store *SidecarStore
 }
 
 // HealthResponse is the JSON body returned by /healthz.
@@ -100,6 +104,7 @@ func NewAdminServer(cfg *AdminConfig) *AdminServer {
 		router:         cfg.Router,
 		clientListener: cfg.ClientListener,
 		emitter:        cfg.Emitter,
+		store:          cfg.Store,
 		logger:         cfg.Logger,
 		socketPath:     cfg.SocketPath,
 		startTime:      time.Now(),
@@ -356,14 +361,20 @@ func (a *AdminServer) createPort(w http.ResponseWriter, r *http.Request) {
 		// Listener started successfully (blocking in accept loop).
 	}
 
-	// Runtime-only: remind the operator that this change is not persisted
-	// to the config file and will be lost on restart. See
-	// docs/api/control-plane.md#persistence.
-	a.logger.Warn("admin: port mapping added at runtime is not persisted; add to relay.yaml to survive restart",
-		"port", req.Port,
-		"customer_id", req.CustomerID,
-		"service", req.Service,
-		"listen_addr", addr)
+	// Persist the new mapping to the sidecar so it survives restart.
+	// If no store is configured, warn that the change will be lost.
+	if a.store != nil {
+		if saveErr := a.store.SaveCurrentState(a.router.ListPorts()); saveErr != nil {
+			a.logger.Warn("admin: failed to persist port mapping to sidecar",
+				"port", req.Port, "error", saveErr)
+		}
+	} else {
+		a.logger.Warn("admin: port mapping added at runtime is not persisted; add to relay.yaml to survive restart",
+			"port", req.Port,
+			"customer_id", req.CustomerID,
+			"service", req.Service,
+			"listen_addr", addr)
+	}
 
 	a.emitAudit(r.Context(), audit.ActionAdminPortAdded,
 		fmt.Sprintf("%d", req.Port), req.CustomerID,
@@ -400,8 +411,15 @@ func (a *AdminServer) deletePort(w http.ResponseWriter, r *http.Request, port in
 			"port", port, "error", err)
 	}
 
-	// Runtime-only: if the port is also defined in relay.yaml, the
-	// config will re-add it on next restart. Warn the operator.
+	// Persist the updated mapping set to the sidecar. If the deleted port
+	// is also defined in relay.yaml, warn that relay.yaml must be updated
+	// separately to prevent the mapping reappearing on next restart.
+	if a.store != nil {
+		if saveErr := a.store.SaveCurrentState(a.router.ListPorts()); saveErr != nil {
+			a.logger.Warn("admin: failed to persist port removal to sidecar",
+				"port", port, "error", saveErr)
+		}
+	}
 	a.logger.Warn("admin: port mapping removed at runtime; also remove from relay.yaml to prevent reappearance on restart",
 		"port", port,
 		"customer_id", customerID)

--- a/pkg/relay/admin.go
+++ b/pkg/relay/admin.go
@@ -161,9 +161,9 @@ func (a *AdminServer) Start(ctx context.Context) error {
 				"path", a.socketPath, "error", err)
 		} else {
 			if chmodErr := os.Chmod(a.socketPath, 0o600); chmodErr != nil {
-			a.logger.Warn("admin: failed to set socket permissions",
-				"path", a.socketPath, "error", chmodErr)
-		}
+				a.logger.Warn("admin: failed to set socket permissions",
+					"path", a.socketPath, "error", chmodErr)
+			}
 			a.logger.Info("relay: admin socket started", "path", a.socketPath)
 
 			if a.server.Addr == "" {

--- a/pkg/relay/store.go
+++ b/pkg/relay/store.go
@@ -17,7 +17,7 @@ type SidecarPort struct {
 	CustomerID string `json:"customer_id"`
 	Service    string `json:"service"`
 	ListenAddr string `json:"listen_addr"`
-	MaxStreams  int    `json:"max_streams"`
+	MaxStreams int    `json:"max_streams"`
 }
 
 // SidecarData is the JSON payload written to and read from the sidecar file.
@@ -117,7 +117,7 @@ func (s *SidecarStore) SaveCurrentState(ports []PortInfo) error {
 			CustomerID: p.CustomerID,
 			Service:    p.Service,
 			ListenAddr: p.ListenAddr,
-			MaxStreams:  p.MaxStreams,
+			MaxStreams: p.MaxStreams,
 		}
 	}
 	return s.Save(&SidecarData{Version: sidecarVersion, Ports: sps})

--- a/pkg/relay/store.go
+++ b/pkg/relay/store.go
@@ -1,0 +1,103 @@
+package relay
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+)
+
+const sidecarVersion = "1"
+
+// SidecarPort is a single port mapping persisted in the sidecar JSON file.
+type SidecarPort struct {
+	Port       int    `json:"port"`
+	CustomerID string `json:"customer_id"`
+	Service    string `json:"service"`
+	ListenAddr string `json:"listen_addr"`
+	MaxStreams  int    `json:"max_streams"`
+}
+
+// SidecarData is the JSON payload written to and read from the sidecar file.
+type SidecarData struct {
+	Version string        `json:"version"`
+	Ports   []SidecarPort `json:"ports"`
+}
+
+// SidecarStore persists runtime port mutations to a JSON file.
+// On relay startup the sidecar is merged into the port index so that
+// ports added via the admin API survive process restarts without
+// requiring relay.yaml to be modified.
+type SidecarStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewSidecarStore returns a SidecarStore backed by the file at path.
+func NewSidecarStore(path string) *SidecarStore {
+	return &SidecarStore{path: path}
+}
+
+// Load reads and parses the sidecar file. If the file does not exist,
+// an empty SidecarData is returned without error. Any other read or
+// parse error is returned to the caller.
+func (s *SidecarStore) Load() (*SidecarData, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &SidecarData{Version: sidecarVersion, Ports: []SidecarPort{}}, nil
+		}
+		return nil, err
+	}
+
+	var data SidecarData
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, fmt.Errorf("sidecar: parse %s: %w", s.path, err)
+	}
+	if data.Ports == nil {
+		data.Ports = []SidecarPort{}
+	}
+	return &data, nil
+}
+
+// Save atomically writes data to the sidecar file. It writes to a
+// temporary file first, then renames it into place.
+func (s *SidecarStore) Save(data *SidecarData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("sidecar: marshal: %w", err)
+	}
+
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return fmt.Errorf("sidecar: write temp: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		os.Remove(tmp) //nolint:errcheck // best-effort cleanup on rename failure
+		return fmt.Errorf("sidecar: rename: %w", err)
+	}
+	return nil
+}
+
+// SaveCurrentState converts a PortInfo snapshot to SidecarData and saves
+// it atomically. Call after createPort or deletePort succeeds.
+func (s *SidecarStore) SaveCurrentState(ports []PortInfo) error {
+	sps := make([]SidecarPort, len(ports))
+	for i, p := range ports {
+		sps[i] = SidecarPort{
+			Port:       p.Port,
+			CustomerID: p.CustomerID,
+			Service:    p.Service,
+			ListenAddr: p.ListenAddr,
+			MaxStreams:  p.MaxStreams,
+		}
+	}
+	return s.Save(&SidecarData{Version: sidecarVersion, Ports: sps})
+}

--- a/pkg/relay/store.go
+++ b/pkg/relay/store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -42,11 +43,14 @@ func NewSidecarStore(path string) *SidecarStore {
 // Load reads and parses the sidecar file. If the file does not exist,
 // an empty SidecarData is returned without error. Any other read or
 // parse error is returned to the caller.
+//
+// The mutex is held only for the file read; unmarshaling happens outside
+// the lock to keep the critical section short.
 func (s *SidecarStore) Load() (*SidecarData, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	b, err := os.ReadFile(s.path)
+	s.mu.Unlock()
+
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return &SidecarData{Version: sidecarVersion, Ports: []SidecarPort{}}, nil
@@ -58,14 +62,18 @@ func (s *SidecarStore) Load() (*SidecarData, error) {
 	if err := json.Unmarshal(b, &data); err != nil {
 		return nil, fmt.Errorf("sidecar: parse %s: %w", s.path, err)
 	}
+	if data.Version != sidecarVersion {
+		return nil, fmt.Errorf("sidecar: unsupported version %q (want %q)", data.Version, sidecarVersion)
+	}
 	if data.Ports == nil {
 		data.Ports = []SidecarPort{}
 	}
 	return &data, nil
 }
 
-// Save atomically writes data to the sidecar file. It writes to a
-// temporary file first, then renames it into place.
+// Save atomically writes data to the sidecar file. It creates a temp file
+// with a random suffix in the same directory (guaranteeing same-filesystem
+// rename), then renames it into place.
 func (s *SidecarStore) Save(data *SidecarData) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -75,12 +83,25 @@ func (s *SidecarStore) Save(data *SidecarData) error {
 		return fmt.Errorf("sidecar: marshal: %w", err)
 	}
 
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o600); err != nil {
-		return fmt.Errorf("sidecar: write temp: %w", err)
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".sidecar-*.tmp")
+	if err != nil {
+		return fmt.Errorf("sidecar: create temp: %w", err)
 	}
-	if err := os.Rename(tmp, s.path); err != nil {
-		os.Remove(tmp) //nolint:errcheck // best-effort cleanup on rename failure
+	tmpName := tmp.Name()
+
+	_, writeErr := tmp.Write(b)
+	closeErr := tmp.Close()
+	if writeErr != nil || closeErr != nil {
+		os.Remove(tmpName) //nolint:errcheck // best-effort cleanup
+		if writeErr != nil {
+			return fmt.Errorf("sidecar: write temp: %w", writeErr)
+		}
+		return fmt.Errorf("sidecar: close temp: %w", closeErr)
+	}
+
+	if err := os.Rename(tmpName, s.path); err != nil {
+		os.Remove(tmpName) //nolint:errcheck // best-effort cleanup on rename failure
 		return fmt.Errorf("sidecar: rename: %w", err)
 	}
 	return nil

--- a/pkg/relay/store_test.go
+++ b/pkg/relay/store_test.go
@@ -152,7 +152,7 @@ func TestSidecarStore_SaveCurrentState_RoundTrip(t *testing.T) {
 func TestSidecarStore_LoadVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sidecar.json")
-	// Write a file with an unrecognised version.
+	// Write a file with an unrecognized version.
 	require.NoError(t, os.WriteFile(path, []byte(`{"version":"99","ports":[]}`), 0o600))
 
 	s := NewSidecarStore(path)

--- a/pkg/relay/store_test.go
+++ b/pkg/relay/store_test.go
@@ -62,8 +62,13 @@ func TestSidecarStore_AtomicWrite_NoTmpFile(t *testing.T) {
 
 	require.NoError(t, s.Save(data))
 
-	_, err := os.Stat(path + ".tmp")
-	assert.True(t, os.IsNotExist(err), "temp file must not exist after successful Save")
+	// The tmp file uses a random suffix now, so we check no .tmp files remain.
+	entries, readErr := os.ReadDir(dir)
+	require.NoError(t, readErr)
+	for _, e := range entries {
+		assert.False(t, filepath.Ext(e.Name()) == ".tmp",
+			"no .tmp files should remain after successful Save, found: %s", e.Name())
+	}
 }
 
 func TestSidecarStore_SaveCurrentState(t *testing.T) {
@@ -144,10 +149,21 @@ func TestSidecarStore_SaveCurrentState_RoundTrip(t *testing.T) {
 	assert.Empty(t, got.Ports)
 }
 
+func TestSidecarStore_LoadVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.json")
+	// Write a file with an unrecognised version.
+	require.NoError(t, os.WriteFile(path, []byte(`{"version":"99","ports":[]}`), 0o600))
+
+	s := NewSidecarStore(path)
+	_, err := s.Load()
+	assert.ErrorContains(t, err, "unsupported version")
+}
+
 // TestSidecarData_JSONSchema verifies the JSON field names match the spec.
 func TestSidecarData_JSONSchema(t *testing.T) {
 	data := SidecarData{
-		Version: "1",
+		Version: sidecarVersion,
 		Ports: []SidecarPort{
 			{Port: 1234, CustomerID: "c1", Service: "s1", ListenAddr: "0.0.0.0", MaxStreams: 3},
 		},

--- a/pkg/relay/store_test.go
+++ b/pkg/relay/store_test.go
@@ -1,0 +1,176 @@
+package relay
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSidecarStore_LoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSidecarStore(filepath.Join(dir, "sidecar.json"))
+
+	data, err := s.Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, sidecarVersion, data.Version)
+	assert.Empty(t, data.Ports)
+}
+
+func TestSidecarStore_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSidecarStore(filepath.Join(dir, "sidecar.json"))
+
+	want := &SidecarData{
+		Version: sidecarVersion,
+		Ports: []SidecarPort{
+			{Port: 8080, CustomerID: "cust-a", Service: "http", ListenAddr: "0.0.0.0", MaxStreams: 10},
+			{Port: 4433, CustomerID: "cust-b", Service: "smb", ListenAddr: "127.0.0.1", MaxStreams: 5},
+		},
+	}
+
+	require.NoError(t, s.Save(want))
+
+	got, err := s.Load()
+	require.NoError(t, err)
+	assert.Equal(t, want.Version, got.Version)
+	assert.Equal(t, len(want.Ports), len(got.Ports))
+
+	// Build a map for order-independent comparison.
+	byPort := make(map[int]SidecarPort, len(got.Ports))
+	for _, sp := range got.Ports {
+		byPort[sp.Port] = sp
+	}
+	for _, sp := range want.Ports {
+		assert.Equal(t, sp, byPort[sp.Port])
+	}
+}
+
+func TestSidecarStore_AtomicWrite_NoTmpFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.json")
+	s := NewSidecarStore(path)
+
+	data := &SidecarData{
+		Version: sidecarVersion,
+		Ports:   []SidecarPort{{Port: 9000, CustomerID: "cust-c", Service: "api", ListenAddr: "0.0.0.0"}},
+	}
+
+	require.NoError(t, s.Save(data))
+
+	_, err := os.Stat(path + ".tmp")
+	assert.True(t, os.IsNotExist(err), "temp file must not exist after successful Save")
+}
+
+func TestSidecarStore_SaveCurrentState(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSidecarStore(filepath.Join(dir, "sidecar.json"))
+
+	ports := []PortInfo{
+		{Port: 7070, CustomerID: "cust-d", Service: "dash", ListenAddr: "0.0.0.0", MaxStreams: 20},
+		{Port: 7071, CustomerID: "cust-d", Service: "dash-api", ListenAddr: "0.0.0.0", MaxStreams: 20},
+	}
+
+	require.NoError(t, s.SaveCurrentState(ports))
+
+	got, err := s.Load()
+	require.NoError(t, err)
+	assert.Equal(t, sidecarVersion, got.Version)
+	assert.Len(t, got.Ports, 2)
+
+	byPort := make(map[int]SidecarPort, len(got.Ports))
+	for _, sp := range got.Ports {
+		byPort[sp.Port] = sp
+	}
+
+	assert.Equal(t, "cust-d", byPort[7070].CustomerID)
+	assert.Equal(t, "dash", byPort[7070].Service)
+	assert.Equal(t, 20, byPort[7070].MaxStreams)
+	assert.Equal(t, "dash-api", byPort[7071].Service)
+}
+
+func TestSidecarStore_SaveCurrentState_Empty(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSidecarStore(filepath.Join(dir, "sidecar.json"))
+
+	require.NoError(t, s.SaveCurrentState(nil))
+
+	got, err := s.Load()
+	require.NoError(t, err)
+	assert.Empty(t, got.Ports)
+}
+
+func TestSidecarStore_LoadCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.json")
+	require.NoError(t, os.WriteFile(path, []byte("not valid json {{{"), 0o600))
+
+	s := NewSidecarStore(path)
+	_, err := s.Load()
+	assert.Error(t, err)
+}
+
+func TestSidecarStore_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.json")
+	s := NewSidecarStore(path)
+
+	require.NoError(t, s.Save(&SidecarData{Version: sidecarVersion, Ports: []SidecarPort{}}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestSidecarStore_SaveCurrentState_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSidecarStore(filepath.Join(dir, "sidecar.json"))
+
+	// Simulate create then delete cycle.
+	ports := []PortInfo{
+		{Port: 5000, CustomerID: "cust-e", Service: "svc1", ListenAddr: "0.0.0.0", MaxStreams: 0},
+	}
+	require.NoError(t, s.SaveCurrentState(ports))
+
+	// Simulate delete: save empty state.
+	require.NoError(t, s.SaveCurrentState([]PortInfo{}))
+
+	got, err := s.Load()
+	require.NoError(t, err)
+	assert.Empty(t, got.Ports)
+}
+
+// TestSidecarData_JSONSchema verifies the JSON field names match the spec.
+func TestSidecarData_JSONSchema(t *testing.T) {
+	data := SidecarData{
+		Version: "1",
+		Ports: []SidecarPort{
+			{Port: 1234, CustomerID: "c1", Service: "s1", ListenAddr: "0.0.0.0", MaxStreams: 3},
+		},
+	}
+
+	b, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+
+	assert.Contains(t, m, "version")
+	assert.Contains(t, m, "ports")
+
+	ports, ok := m["ports"].([]any)
+	require.True(t, ok)
+	require.Len(t, ports, 1)
+
+	entry, ok := ports[0].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, entry, "port")
+	assert.Contains(t, entry, "customer_id")
+	assert.Contains(t, entry, "service")
+	assert.Contains(t, entry, "listen_addr")
+	assert.Contains(t, entry, "max_streams")
+}


### PR DESCRIPTION
## Summary

- Introduces `SidecarStore` in `pkg/relay/store.go` — atomic JSON file that persists runtime port mutations across relay restarts
- `createPort` and `deletePort` call `SaveCurrentState` after each mutation; nil store falls back to the existing \"not persisted\" warning (no behaviour change for unconfigured deployments)
- Startup merge in `cmd/relay/main.go`: sidecar ports not already in the port index (from `relay.yaml`) are added to it; `relay.yaml` entries always win on conflict
- New `store_path` field in `ServerConfig` / `relay.yaml`; commented example added to `relay.example.yaml`

## Design notes

- FRP-style sidecar: `relay.yaml` is never written. The sidecar tracks runtime deltas only.
- Atomic write: write to `<path>.tmp`, rename into place. No partial writes.
- File permissions: `0600` (owner read/write only).
- 8 new tests: round-trip, missing file, atomic write, permissions, corrupt JSON, create/delete cycle, JSON schema.

## Test plan

- [ ] All 6 `pkg/...` packages pass with `-race`
- [ ] `TestSidecarStore_*` all pass
- [ ] `createPort` with `store_path` set: sidecar file created and contains the new port
- [ ] `deletePort`: sidecar file updated to remove the deleted port
- [ ] Restart relay with sidecar: previously-added ports re-appear without editing `relay.yaml`
- [ ] `relay.yaml` port and same port in sidecar: relay.yaml wins (no duplicate)
- [ ] No `store_path` set: existing \"not persisted\" warn still emitted