### PR TITLE
feat(relay): add agent_certs to GET /status

### DIFF
--- a/docs/api/control-plane.md
+++ b/docs/api/control-plane.md
@@ -95,6 +95,41 @@ Relay uptime and current connection state.
 
 ---
 
+### GET /status
+
+Unified relay status snapshot for operator dashboards and the `ats` CLI. Superset of `/stats` with cert expiry data.
+
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "uptime": "1h23m45s",
+  "uptime_seconds": 5025.0,
+  "agents_connected": 2,
+  "streams_active": 15,
+  "ports_active": 3,
+  "config_version": "v0.1.3",
+  "relay_certs": [
+    { "name": "relay", "expires_at": "2026-07-15T00:00:00Z", "days_left": 89 }
+  ],
+  "agent_certs": [
+    { "name": "customer-001", "expires_at": "2026-07-15T00:00:00Z", "days_left": 89 }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `relay_certs` | Expiry of relay-side certificates (parsed from config TLS paths on each call) |
+| `agent_certs` | Expiry of connected agents' mTLS client certificates (from `CmdServiceList` handshake; omitted for agents with zero-value NotAfter) |
+
+Missing or malformed cert files are skipped with a warn log; the endpoint always returns 200. Empty arrays serialize as `[]`, not `null`. No secret material or cert body content is exposed -- only NotAfter and a display name.
+
+**Error:** `405 Method Not Allowed` on non-GET.
+
+---
+
 ### GET /ports
 
 List all active port-to-customer mappings.
@@ -182,6 +217,35 @@ Remove a port mapping and stop the TCP listener.
 - `405 Method Not Allowed` -- non-DELETE method
 
 **Behavior:** Removes the routing entry AND stops the TCP listener. If the listener was started from config (not the admin API), the stop is a no-op and a warning is logged.
+
+---
+
+### PUT /ports/{port}
+
+Update the mutable fields of an existing port mapping without delete-recreate. The tenant binding (`customer_id`) is immutable through this endpoint.
+
+**Request:**
+
+```json
+{
+  "service": "smb-v2",
+  "listen_addr": "127.0.0.1",
+  "max_streams": 200
+}
+```
+
+At least one field must be present. `max_streams` uses pointer semantics: omitted or `null` preserves the current value; explicit `0` means unlimited; positive sets a new cap. `listen_addr` must be a literal IP.
+
+**Success:** `200 OK` with the updated `PortResponse`.
+
+**Errors:**
+- `400 Bad Request` -- empty body, invalid JSON, invalid listen_addr, or negative max_streams
+- `404 Not Found` -- no mapping for this port
+- `405 Method Not Allowed` -- methods other than GET, PUT, or DELETE
+
+**Security invariant:** `customer_id` is **immutable** via PUT. The request struct has no customer_id field and the router preserves the existing binding verbatim. A tenant reassignment requires an explicit DELETE then POST, each audited separately.
+
+**Audit event:** `admin.port_updated`
 
 ---
 

--- a/pkg/relay/admin_status.go
+++ b/pkg/relay/admin_status.go
@@ -21,6 +21,7 @@ type StatusResponse struct {
 	PortsActive     int          `json:"ports_active"`
 	ConfigVersion   string       `json:"config_version"`
 	RelayCerts      []CertExpiry `json:"relay_certs"`
+	AgentCerts      []CertExpiry `json:"agent_certs"`
 }
 
 // CertExpiry describes when a single relay-side certificate expires.
@@ -64,6 +65,7 @@ func (a *AdminServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	ports := a.router.ListPorts()
 	uptime := time.Since(a.startTime)
 	relayCerts := a.collectRelayCerts()
+	agentCerts := collectAgentCerts(agents)
 
 	writeJSON(w, StatusResponse{
 		Status:          "ok",
@@ -74,6 +76,7 @@ func (a *AdminServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		PortsActive:     len(ports),
 		ConfigVersion:   a.configVersion,
 		RelayCerts:      relayCerts,
+		AgentCerts:      agentCerts,
 	})
 }
 
@@ -95,6 +98,26 @@ func (a *AdminServer) collectRelayCerts() []CertExpiry {
 			continue
 		}
 		out = append(out, entry)
+	}
+	return out
+}
+
+// collectAgentCerts builds a CertExpiry entry for each connected agent
+// whose CertNotAfter is non-zero. The slice is always non-nil.
+func collectAgentCerts(agents []AgentInfo) []CertExpiry {
+	out := make([]CertExpiry, 0, len(agents))
+	for i := range agents {
+		ag := &agents[i]
+		if ag.CertNotAfter.IsZero() {
+			continue
+		}
+		now := time.Now()
+		daysLeft := int(ag.CertNotAfter.Sub(now).Hours() / 24)
+		out = append(out, CertExpiry{
+			Name:      ag.CustomerID,
+			ExpiresAt: ag.CertNotAfter.UTC().Format(time.RFC3339),
+			DaysLeft:  daysLeft,
+		})
 	}
 	return out
 }

--- a/pkg/relay/admin_status.go
+++ b/pkg/relay/admin_status.go
@@ -58,8 +58,8 @@ func (a *AdminServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	totalStreams := 0
-	for _, ag := range agents {
-		totalStreams += ag.StreamCount
+	for i := range agents {
+		totalStreams += agents[i].StreamCount
 	}
 
 	ports := a.router.ListPorts()

--- a/pkg/relay/admin_status_test.go
+++ b/pkg/relay/admin_status_test.go
@@ -156,6 +156,36 @@ func TestAdmin_Status_AgentCount(t *testing.T) {
 	assert.GreaterOrEqual(t, status.StreamsActive, 0)
 }
 
+func TestAdmin_Status_AgentCerts(t *testing.T) {
+	addr, reg, _ := testAdminServerWithStatus(t, nil, "test")
+
+	// Register an agent with a cert expiry set.
+	conn, agentMux := testConnectionPair("customer-cert-1")
+	defer conn.Close()
+	defer agentMux.Close()
+	expiry := time.Now().Add(60 * 24 * time.Hour) // 60 days
+	conn.SetCertNotAfter(expiry)
+	require.NoError(t, reg.Register(context.Background(), "customer-cert-1", conn))
+
+	status := getStatus(t, addr)
+	require.Len(t, status.AgentCerts, 1)
+	assert.Equal(t, "customer-cert-1", status.AgentCerts[0].Name)
+	assert.True(t, status.AgentCerts[0].DaysLeft >= 59)
+}
+
+func TestAdmin_Status_AgentCerts_ZeroNotAfterOmitted(t *testing.T) {
+	addr, reg, _ := testAdminServerWithStatus(t, nil, "test")
+
+	// Register an agent with no cert expiry (zero value).
+	conn, agentMux := testConnectionPair("customer-no-cert")
+	defer conn.Close()
+	defer agentMux.Close()
+	require.NoError(t, reg.Register(context.Background(), "customer-no-cert", conn))
+
+	status := getStatus(t, addr)
+	assert.Empty(t, status.AgentCerts)
+}
+
 func TestAdmin_Status_PortCount(t *testing.T) {
 	addr, _, router := testAdminServerWithStatus(t, nil, "test")
 


### PR DESCRIPTION
## Summary
- Wires `AgentInfo.CertNotAfter` (from #109 CmdServiceList) into `handleStatus` (from #107 GET /status) as a new `agent_certs` field
- Agents with zero-value NotAfter are omitted from the array
- Also backfills missing `PUT /ports/{port}` and `GET /status` sections in `docs/api/control-plane.md` that were not staged during the original Phase 3 commits

## Files changed
- `pkg/relay/admin_status.go` -- `AgentCerts` field on `StatusResponse`, `collectAgentCerts` helper
- `pkg/relay/admin_status_test.go` -- 2 new tests (`AgentCerts`, `ZeroNotAfterOmitted`)
- `docs/api/control-plane.md` -- PUT /ports/{port}, GET /status, agent_certs field

## Test plan
- [x] `go test ./pkg/relay/... -race` passes
- [x] 2 new tests verify agent cert population and zero-value omission